### PR TITLE
Fixes stdin redirection issues within the command-line module. 

### DIFF
--- a/lib/command-line.js
+++ b/lib/command-line.js
@@ -5,11 +5,18 @@ var childProcess = require('child_process'),
     log = require('./log'),
     windows = (process.platform.indexOf("win32") >= 0 || process.platform.indexOf("win64") >= 0);
 
-function run(command, args, callback, options) {
+function run(command, args, options, callback) {
     "use strict";
     var pro,
         stdOut = "",
         stdErr = "";
+
+	// Options argument is optional, if callback is undefined, assume options
+	// argument is the callback
+	if (!callback) {
+		callback = options;
+		options = {};
+	}
 
     options = options || {}
     options.stdout = options.stdout || 'inherit';

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -48,7 +48,7 @@ exports.run = function() {
                 getInstalledSassGemVersion(function(version) {
                     if (version === -1 || semver.lt(version, requiredSassGemVersion)) {
                         log.primary("Install sass gem");
-                        commandLine.run('gem', ['install', 'sass', '-v', requiredSassGemVersion], callback, { stderr: 'pipe', stdout: 'pipe' });
+                        commandLine.run('gem', ['install', 'sass', '-v', requiredSassGemVersion], { stderr: 'pipe', stdout: 'pipe' }, callback);
                     } else {
                         log.secondary("sass gem " + version + " already installed.");
                         callback();
@@ -62,7 +62,7 @@ exports.run = function() {
             getInstalledBowerVersion(function(version) {
                 if (version === -1 || semver.lt(version, requiredBowerVersion)) {
                     log.primary("Install Bower...");
-                    commandLine.run('npm', ['install', 'bower', '--quiet'], callback, { stderr: 'pipe', stdout: 'pipe' });
+                    commandLine.run('npm', ['install', 'bower', '--quiet'], { stderr: 'pipe', stdout: 'pipe' }, callback);
                 } else {
                     log.secondary("Bower " + version + " already installed");
                     callback();
@@ -72,7 +72,7 @@ exports.run = function() {
         function(callback) {
             if (files.packageJsonExists()) {
                 log.primary("npm install...");
-                commandLine.run('npm', ['install'], callback, { stderr: 'pipe', stdout: 'pipe' });
+                commandLine.run('npm', ['install'], { stderr: 'pipe', stdout: 'pipe' }, callback);
             } else {
                 log.secondary("no package.json, skip npm install...");
                 callback();
@@ -88,7 +88,7 @@ exports.run = function() {
 						'--config.registry.search=https://bower.herokuapp.com'
 					];
 
-                commandLine.run(bowerCommand, bowerArgs, callback, { stderr: 'pipe', stdout: 'pipe' });
+                commandLine.run(bowerCommand, bowerArgs, { stderr: 'pipe', stdout: 'pipe' }, callback);
             } else {
                 log.secondary("no bower.json, skip bower install...");
                 callback();

--- a/lib/sass.js
+++ b/lib/sass.js
@@ -30,7 +30,7 @@ function compile(src, dest, options, callback) {
         args.push('--sourcemap');
     }
 
-    commandLine.run('sass', args.concat(['--scss', src, dest]), callback, { stdio: 'inherit' });
+    commandLine.run('sass', args.concat(['--scss', src, dest]), { stdio: 'inherit' }, callback);
 }
 
 function compileWithVars(src, dest, vars, options, callback) {


### PR DESCRIPTION
Previously the callback passed into `command-line.run` would receive the argument list:
`stderr, stdout`, however, these were not populated by the command-line module correctly
as `stdio` was always set to 'inherit' in the `spawn` function call.

This meant that the `error` argument of the callback would always be a _falsey_
empty string; the `stdout` stream from `sass --version` was being sent directly to the real 'stdout' and therefore could not be read and checked. The result of this was that the sass gem was always downloaded
and an installation attempted each time `origami install` was run regardless of any current installation. 

This alters the command-line module's API slightly adding an optional `option` argument for controlling stderr and stdout (which takes the same arguments as the [Node API for spawning child processes](http://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).  

We should be able to avoid using `proc.spawn` and the often required associated stream handling for simple cases, and instead use this module with a little more flexibility.

Specifically this makes it easier to reuse the command-line module to run the linting tools described in issue #28.
