### PR TITLE
Make sure empty lines don't get translated into ignores in the .gitignore file

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -134,7 +134,7 @@ function getGitIgnorePaths() {
 
     // Split the file list, and then add then make absolute by mapping
     // (path) -> (dir)/(path)
-    return ignoreFiles.split('\n').map(function(pathName) {
+    return ignoreFiles.split('\n').filter(function(path) { return path !== '';  }).map(function(pathName) {
         return path.join(process.cwd(), pathName);
     });
 }


### PR DESCRIPTION
Filters out empty lines in the .gitignore file so they don't get interpreted as exclusions. In issue #35 this caused the entire repo to be ignored when verifying.
