### PR TITLE
Only try and transform the output of the linter if an error occurred

### DIFF
--- a/lib/commands/verify.js
+++ b/lib/commands/verify.js
@@ -148,17 +148,20 @@ exports.run = function(callback) {
     async.map(verifierTasks, function(task, mapCallback) {
 
         task.run(function(err, output) {
-			var transformedOutput = err.stdout;
+			var transformedOutput = '';
+			if (err) {
+				transformedOutput = err.stdout;
 
-			if (task.transformOutput) {
-				transformedOutput = task.transformOutput(transformedOutput);
+				if (task.transformOutput) {
+					transformedOutput = task.transformOutput(transformedOutput);
+				}
 			}
 
-            var wrappedError = err ? {
-                'err': err,
-                'stdout': transformedOutput,
-                'name': task.name
-            } : false;
+			var wrappedError = err ? {
+				'err': err,
+				'stdout': transformedOutput,
+				'name': task.name
+			} : false;
 
             mapCallback(false, wrappedError);
         });


### PR DESCRIPTION
Fixes issue where the verify command would error when using watch when scss-lint would run error free.
