### PR TITLE
Remove uglify

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -5,7 +5,6 @@ var browserify = require('browserify'),
     streamify = require('gulp-streamify'),
     sass = require('gulp-ruby-sass'),
     csso = require('gulp-csso'),
-    uglify = require('gulp-uglify'),
     rename = require('gulp-rename'),
     files = require('../helpers/files'),
     log = require('../helpers/log');
@@ -27,7 +26,6 @@ module.exports.js = function(gulp, config) {
             .transform({}, 'textrequireify')
             .bundle({debug: true})
             .pipe(source(dest))
-            .pipe(streamify(uglify()))
             .pipe(gulp.dest(destFolder));
     }
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gulp-ruby-sass": "^0.7.1",
     "gulp-scss-lint": "^0.1.3",
     "gulp-streamify": "0.0.5",
-    "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "gulp-webserver": "^0.8.3",
     "minimist": "0.0.8",


### PR DESCRIPTION
hi @triblondon - I wonder whether this could be considered...

Reasoning:-
- The tool we're using for js compression is closure compiler rather than uglify so if we were to need this we ought to use the same tool.
- It makes it difficult to do development on components, which is the primary use case for obt [ especially as sourcemaps aren't supported right now ]
- If we put in a compression task it would be better if it was opt-out-able.
