### PR TITLE
Refactor gitignore to support comments, \r\n and inclusions, also convert indent to tabs

### DIFF
--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -17,32 +17,48 @@ module.exports = function(gulp, config) {
 };
 
 function pathsToGlob(paths) {
-    for (var i = 0; i < paths.length; i++) {
-        var currentPath = path.join(process.cwd(), paths[i]);
-	    var isExistingDirectory = fs.existsSync(currentPath) && fs.statSync(currentPath).isDirectory();
+	var globPatterns = [];
+	function filterEmptyAndComments(line) { 
+		return line && line[0] !== '#';
+	}
 
-	    if (isExistingDirectory) {
-	        currentPath = path.join(currentPath, '/**');
-	    }
-	    paths[i] = '!'+currentPath;
-    }
-    return paths;
+	function createGlobPatterns(line){
+		// if the line starts with a ! it's an inclusion so we remove the ! otherwise we add ! to make it an exclusion
+		if(line[0] === '!'){
+			line = line.substring(1);
+		} else {
+			line = '!' + line;
+		}
+
+		// if it's a directory add ** to exclude everything within
+		if(line[line.length - 1] === '/'){
+			line += '**';
+		} else {
+			globPatterns.push(line + '/**');
+		}
+
+		globPatterns.push(line);
+		return line;
+	}
+
+	paths.filter(filterEmptyAndComments).forEach(createGlobPatterns);
+	return globPatterns;
 }
 
 /**
  * Run the SCSS gulp plugin.
  */
 module.exports.scssLint = function(gulp, config) {
-    if (!config.sass && !files.getMainSassPath()) {
-        log.secondaryError('No main.scss');
-        return;
-    }
-    var configPath = path.join(__dirname, '/../../config/scss-lint.yml');
+	if (!config.sass && !files.getMainSassPath()) {
+		log.secondaryError('No main.scss');
+		return;
+	}
+	var configPath = path.join(__dirname, '/../../config/scss-lint.yml');
 
-    return gulp.src(['**/*.scss'].concat(excludeFiles))
-    	.pipe(scsslint({
-    		'config': configPath
-    	}));
+	return gulp.src(['**/*.scss'].concat(excludeFiles))
+		.pipe(scsslint({
+			'config': configPath
+		}));
 };
 
 /**
@@ -54,7 +70,7 @@ module.exports.jsHint = function(gulp, config) {
 		return;
 	}
 
-    var configPath = path.join(__dirname, '/../../config/jshint.json');
+	var configPath = path.join(__dirname, '/../../config/jshint.json');
 
 	return gulp.src(['**/*.js'].concat(excludeFiles))
 			.pipe(jshint(configPath))


### PR DESCRIPTION
The function will now add 2 glob patterns per line in the gitignore, one that is just the line and one ending in /*\* in case the line pertains to a folder, unless the line ends with a / in this case it is assumed the user only wanted to exclude the folder. 
