### PR TITLE
Fix verify for .gitignore with windows line breaks

### DIFF
--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -12,7 +12,7 @@ var files = require('../helpers/files'),
 	excludeFiles = [];
 
 if (fs.existsSync(excludePath)) {
-	excludeFiles = pathsToGlob(fs.readFileSync(excludePath).toString().split('\n'));
+	excludeFiles = pathsToGlob(fs.readFileSync(excludePath).toString().split(/\r?\n/));
 } else {
 	log.secondary('No .gitignore found so command will run on all files in your project');
 }


### PR DESCRIPTION
I must have removed this at some point when I refactored verify, this fixes the gitignore problems on windows, I tested it with Roland yesterday and now verify works fine for him.
