### PR TITLE
Disable sourcemaps by default

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -79,12 +79,14 @@ module.exports.sass = function(gulp, config) {
 				sassConfig.style = 'compressed';
 			}
 			// Sourcemaps aren't compatible with csso, we'll look for a work-around when gulp-ruby-sass 1.0 is released
+			sassConfig.sourcemap = 'none';
 			// if (config.sourcemap) {
 			//     sassConfig.sourcemap = config.sourcemap;
 			// }
 			// if (config.sourcemapPath) {
 			//     sassConfig.sourcemapPath = config.sourcemapPath;
 			// }
+
 			return gulp.src(src)
 				.pipe(sass(sassConfig))
 				.pipe(gulpif(config.env === 'production', csso()))


### PR DESCRIPTION
Sass 3.4 has sourcemaps enabled by default. This setting turns it off.
