### PR TITLE
Disable sourcemaps explicitly

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -87,6 +87,8 @@ module.exports.sass = function(gulp, config) {
 			sassConfig.style = 'compressed';
 		}
 		// Sourcemaps aren't compatible with csso, we'll look for a work-around when gulp-ruby-sass 1.0 is released
+		// in the time being, we disable them explicitly
+		sassConfig.sourcemap = 'none';
 		// if (config.sourcemap) {
 		//     sassConfig.sourcemap = config.sourcemap;
 		// }


### PR DESCRIPTION
Sass 3.4 has sourcemaps enabled by default. This setting turns it off.
