### PR TITLE
JSHint should still run even if there is no main.js

### DIFF
--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var files = require('../helpers/files');
 var log = require('../helpers/log');
 var path = require('path');
 var fs = require('fs');
@@ -62,10 +61,6 @@ function pathsToGlob(paths) {
  */
 module.exports.scssLint = function(gulp, config) {
 	config = config || {};
-	if (!config.sass && !files.getMainSassPath()) {
-		log.secondaryError('No main.scss');
-		return;
-	}
 	var configPath = config.scssLintPath || path.join(__dirname, '/../../config/scss-lint.yml');
 
 	return gulp.src(['**/*.scss'].concat(excludeFiles))


### PR DESCRIPTION
e.g. maybe you have... custom build scripts, tests or other pieces of JavaScript - all still should be linted
