### PR TITLE
Allow external connections to demos

### DIFF
--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -288,7 +288,8 @@ module.exports.runServer = function(gulp) {
 		server = gulp.src('.')
 			.pipe(webserver({
 				directoryListing: true,
-				port: port
+				port: port,
+				host: '0.0.0.0'
 			}));
 		return server;
 	});


### PR DESCRIPTION
For example from a VM, by creating a demo server on 0.0.0.0 to allow external connections, instead of localhost that would only allow connections from the current machine.

Thanks @samgiles for telling me what the fix was. I am just the messenger.
