### PR TITLE
Do not prefer global

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "origami-build-tools",
-  "preferGlobal": true,
   "version": "2.6.1",
   "description": "Origami component development tools.",
   "main": "./lib/origami-build-tools",


### PR DESCRIPTION
> Standardised build tools for Origami modules and products developed based on these modules.

A product will often depend on it non-globally installed so since all this does is add an (unnecessary) warning, best to delete? 