### PR TITLE
Set node:true in jshint.json

### DIFF
--- a/config/jshint.json
+++ b/config/jshint.json
@@ -22,5 +22,6 @@
 
 	"browser": true,
 	"nonstandard": true,
-	"predef": ["require", "module", "exports", "requireText"]
+	"predef": ["requireText"],
+	"node": true
 }


### PR DESCRIPTION
May I request that we replace the current `predef` for `require`, `module`, etc for `node: true` in our jshint config?

This is so that OBT is able to better fulfil its stated goal of…

> Standardised build tools for Origami modules and **products developed based on these modules**.

This option effectively slightly relaxes the linting (not showing warnings if you use globals such as `require`, `module`, `console`, `process`, …

> This option defines globals available when your code is running inside of the Node runtime environment. Node.js is a server-side JavaScript environment that uses an asynchronous event-driven model. This option also skips some warnings that make sense in the browser environments but don't make sense in Node such as file-level use strict pragmas and console.log statements.
