### PR TITLE
Fix dependency error on windows by using a different git URL syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "browserify": "~3.44.2",
     "colors": "^0.6.2",
     "configstore": "^0.3.1",
-    "debowerify": "git+https://github.com/Financial-Times/debowerify.git",
+    "debowerify": "Financial-Times/debowerify",
     "es6-promise": "^1.0.0",
     "findit": "^1.1.1",
     "gulp": "^3.8.7",


### PR DESCRIPTION
Fix for issue #172