### PR TITLE
Adding compress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ automatically re-build the module's demos and assets every time a file changes:
 All the tasks are built using [gulp](http://gulpjs.com/), and almost all of them return a stream. They are structured in 5 higher level tasks, and each one has one or more subtasks.
 
 	Usage: origami-build-tools <command> [<options>]
-	
+
 	Commands:
 	   install  Install system and local dependencies
 	   build    Build module in current directory
@@ -36,7 +36,7 @@ All the tasks are built using [gulp](http://gulpjs.com/), and almost all of them
 	   verify   Lint code and verify if module structure follows the Origami specification
 	   test     Test if Sass silent compilation follows the Origami specification
 	   docs     Build module documentation into the docs/ directory
-	
+
 	Mostly used options include:
 	   [--watch]                    Re-run every time a file changes
 	   [--local]                    Build demos locally, and preview them in a browser
@@ -78,11 +78,12 @@ Build CSS and JavaScript bundles (typically, from `main.js` and `main.css`).
 Runs:
 
 * __js(gulp, config)__ Config accepts:
-	- js: `String` Path to your main JavaScript file. (Default: './main.js' and checks your bower.json to see if it's in its main key) 
+	- js: `String` Path to your main JavaScript file. (Default: './main.js' and checks your bower.json to see if it's in its main key)
 	- buildJs: `String` Name of the built JavaScript bundle. (Default: 'main.js')
 	- buildFolder: `String` Path to directory where the built file will be created. (Default: './build/')
 	- env: `String` It can be either 'production' or 'development'. If it's 'production', it will run [uglify](https://github.com/mishoo/UglifyJS2). If it's 'development', it will generate a sourcemap. (Default: 'development')
 	- sourcemaps: `Boolean` Set to true to output sourcemaps, even if env is 'development'
+	- compress: `Boolean|Object` Set to true to minify js and sass.  Pass object to specify different options for js and sass, eg `{js:true,sass:false}`
 	- transforms: `Array` Additional browserify transforms to run *after* debowerify and textrequireify. Each transform should be specified as one of the following
 		- `String` The name of the transform
 		- `Array` [config, 'transform-name'] Where custom config needs to be passed into the transform use an array containing the config object followed by the transform name
@@ -92,11 +93,12 @@ Runs:
 	- ignoreMissing: See [browserify documentation](https://github.com/substack/node-browserify#usage)
 	- standalone: See [browserify documentation](https://github.com/substack/node-browserify#usage)
 * __sass(gulp, config)__ Config accepts:
-	- sass: `String` Path to your main Sass file. (Default: './main.scss' and checks your bower.json to see if it's in its main key) 
+	- sass: `String` Path to your main Sass file. (Default: './main.scss' and checks your bower.json to see if it's in its main key)
 	- autoprefixerBrowsers: `Array` An array of strings of [browser names for autoprefixer](https://github.com/postcss/autoprefixer#browsers) to check what prefixes it needs. (Default: `["> 1%", "last 2 versions", "ie > 6", "ff ESR"]`)
 	- autoprefixerCascade: `Boolean` Whether autoprefixer should display CSS prefixed properties [cascaded](https://github.com/postcss/autoprefixer#visual-cascade) (Default: false)
 	- autoprefixerRemove: `Boolean` Remove unneeded prefixes (Default: true)
 	- buildCss: `String` Name of the built CSS bundle. (Default: 'main.css')
+	- compress: `Boolean|Object` Set to true to minify js and sass.  Pass object to specify different options for js and sass, eg `{js:false,sass:true}`
 	- buildFolder: `String` Path to directory where the built file will be created. (Default: './build/')
 	- env: `String` It can be either 'production' or 'development'. If it's 'production', it will compile the Sass file with the 'compressed' style option and will also run [csso](https://github.com/css/csso). (Default: 'development')
 
@@ -142,7 +144,7 @@ Runs:
 
 ### `test`
 
-Test [silent compilation](http://origami.ft.com/docs/syntax/scss/#silent-styles).  
+Test [silent compilation](http://origami.ft.com/docs/syntax/scss/#silent-styles).
 If a `$<module-name>-is-silent` variable is found, then runs:
 
 * __silentCompilation(gulp)__ Check the Sass outputs no CSS by default
@@ -161,7 +163,7 @@ Runs:
 
 ## gulpfile usage
 
-Use the build tools in your own Gulp file to incorporate the Origami build process into a *product* (don't use this method if you are building an Origami component). An in depth explanation of how to use the `origami-build-tools` in your product to build Origami modules can be found in the [Origami spec](http://origami.ft.com/docs/developer-guide/building-modules/).  
+Use the build tools in your own Gulp file to incorporate the Origami build process into a *product* (don't use this method if you are building an Origami component). An in depth explanation of how to use the `origami-build-tools` in your product to build Origami modules can be found in the [Origami spec](http://origami.ft.com/docs/developer-guide/building-modules/).
 
 To run these tasks in your `gulpfile.js`, you only need to require `origami-build-tools` and run the task or subtask you need, passing gulp and an optional config object.
 

--- a/config/jshint.json
+++ b/config/jshint.json
@@ -10,7 +10,6 @@
 	"unused": "vars",
 	"strict": true,
 	"trailing": true,
-	"node" : true,
 
 	"esnext": true,
 	"expr": true,

--- a/config/jshint.json
+++ b/config/jshint.json
@@ -10,6 +10,7 @@
 	"unused": "vars",
 	"strict": true,
 	"trailing": true,
+	"node" : true,
 
 	"esnext": true,
 	"expr": true,

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -97,7 +97,7 @@ module.exports.sass = function(gulp, config) {
 			remove: config.autoprefixerRemove === undefined ? true : config.autoprefixerRemove
 		};
 
-		if (compressionEnabled(config, 'scss')) {
+		if (compressionEnabled(config, 'sass')) {
 			sassConfig.style = 'compressed';
 		}
 		// Sourcemaps aren't compatible with csso, we'll look for a work-around when gulp-ruby-sass 1.0 is released

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -12,6 +12,18 @@ var autoprefixer = require('gulp-autoprefixer');
 var files = require('../helpers/files');
 var log = require('../helpers/log');
 
+function compressionEnabled(config, lang){
+	if(typeof config.compress === 'boolean'){
+		return config.compress;
+	}
+
+	if(typeof config.compress === 'object' && lang in config.compress){
+		return config.compress[lang];
+	}
+
+	return config.env === 'production';
+}
+
 module.exports = function(gulp, config) {
 	module.exports.js(gulp, config);
 	module.exports.sass(gulp, config);
@@ -59,7 +71,7 @@ module.exports.js = function(gulp, config) {
 
 		bundle.bundle(config)
 			.pipe(source(dest))
-			.pipe(gulpif(config.env === 'production', streamify(uglify())))
+			.pipe(gulpif(compressionEnabled(config, 'js'), streamify(uglify())))
 			.pipe(gulp.dest(destFolder));
 	}
 };
@@ -85,7 +97,7 @@ module.exports.sass = function(gulp, config) {
 			remove: config.autoprefixerRemove === undefined ? true : config.autoprefixerRemove
 		};
 
-		if (config.env === 'production') {
+		if (compressionEnabled(config, 'scss')) {
 			sassConfig.style = 'compressed';
 		}
 		// Sourcemaps aren't compatible with csso, we'll look for a work-around when gulp-ruby-sass 1.0 is released


### PR DESCRIPTION
For next we want to have sourcemaps in production - this option will make this possible as then we can perform the minification ourselves.

You can specify `true` `false` or object ie: `{js:false,sass:true}`

If the compress option is not specified it falls back to the default behaviour.