### PR TITLE
returning merged stream from build task

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -11,10 +11,13 @@ var gulpif = require('gulp-if');
 var autoprefixer = require('gulp-autoprefixer');
 var files = require('../helpers/files');
 var log = require('../helpers/log');
+var merge = require('merge-stream');
 
 module.exports = function(gulp, config) {
-	module.exports.js(gulp, config);
-	module.exports.sass(gulp, config);
+	return merge(
+		module.exports.js(gulp, config),
+		module.exports.sass(gulp, config)
+	);
 };
 
 module.exports.js = function(gulp, config) {
@@ -57,7 +60,7 @@ module.exports.js = function(gulp, config) {
 			}
 		});
 
-		bundle.bundle(config)
+		return bundle.bundle(config)
 			.pipe(source(dest))
 			.pipe(gulpif(config.env === 'production', streamify(uglify())))
 			.pipe(gulp.dest(destFolder));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "gulp-webserver": "^0.8.3",
+    "merge-stream": "^0.1.6",
     "minimist": "0.0.8",
     "node.extend": "^1.0.9",
     "npmconf": "^1.1.5",


### PR DESCRIPTION
I came across an error whereby the build task reports itself as finished long before it actually has:
![screen shot 2015-01-07 at 15 35 08](https://cloud.githubusercontent.com/assets/18816/5648039/2baf24c4-9683-11e4-946a-83f80cc49596.png)

This makes it impossible to correctly chain other gulp tasks after obt.build.

Now the build method returns a merged stream of the 2 build tasks and this fixes the error:

![screen shot 2015-01-07 at 15 35 55](https://cloud.githubusercontent.com/assets/18816/5648061/5ea75306-9683-11e4-976a-e827088236a6.png)

![screen shot 2015-01-07 at 15 36 07](https://cloud.githubusercontent.com/assets/18816/5648063/60e165c6-9683-11e4-8c61-a5972f3ce392.png)

