### PR TITLE
Update gulp-autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "es6-promise": "^1.0.0",
     "findit": "^1.1.1",
     "gulp": "^3.8.7",
-    "gulp-autoprefixer": "^2.0.0",
+    "gulp-autoprefixer": "^2.1.0",
     "gulp-csso": "^0.2.9",
     "gulp-if": "^1.2.5",
     "gulp-jshint": "^1.8.4",


### PR DESCRIPTION
As a result it updates autoprefixer to from 4.0 to 5.0

https://github.com/postcss/autoprefixer/releases/tag/5.0.0