### PR TITLE
[Sass 3.4] Disable sourcemaps

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -81,7 +81,9 @@ module.exports.sass = function(gulp, config) {
 		config.env = config.env || 'development';
 
 		var sassConfig = {
-			loadPath: ['.', 'bower_components']
+			loadPath: ['.', 'bower_components'],
+			// Hack: we're waiting for gulp-ruby-sass v1 to be released, with better support for soucemaps
+			"sourcemap=none": true
 		};
 
 		var autoprefixerConfig = {
@@ -93,15 +95,6 @@ module.exports.sass = function(gulp, config) {
 		if (config.env === 'production') {
 			sassConfig.style = 'compressed';
 		}
-		// Sourcemaps aren't compatible with csso, we'll look for a work-around when gulp-ruby-sass 1.0 is released
-		// in the time being, we disable them explicitly
-		sassConfig.sourcemap = false;
-		// if (config.sourcemap) {
-		//     sassConfig.sourcemap = config.sourcemap;
-		// }
-		// if (config.sourcemapPath) {
-		//     sassConfig.sourcemapPath = config.sourcemapPath;
-		// }
 		return gulp.src(src)
 			.pipe(sass(sassConfig))
 			.pipe(autoprefixer(autoprefixerConfig))

--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -39,7 +39,12 @@ function buildSass(gulp, demoConfig) {
 			gulp.src(src)
 				.pipe(prefixer(prefixSass))
 				// For the Sass files to load correctly, they need to be in one of these two directories. Sass doesn't look in subdirectories and we can't use wildcards
-				.pipe(sass({loadPath: ['demos/src', 'demos/src/scss', 'bower_components'], style: 'compressed'}))
+				.pipe(sass({
+					loadPath: ['demos/src', 'demos/src/scss', 'bower_components'],
+					style: 'compressed',
+					// Hack: we're waiting for gulp-ruby-sass v1 to be released, with better support for soucemaps
+					"sourcemap=none": true
+				}))
 				.on('error', reject)
 				.pipe(autoprefixer({browsers: ['> 1%', 'last 2 versions', 'ie > 6', 'ff ESR'], cascade: false}))
 				.pipe(gulp.dest(dest))

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -19,7 +19,7 @@ function silentCompilationTest(gulp, silent) {
 						var sassVar = '$' + files.getBowerJson().name + '-is-silent: ' + silent + ';\n';
 						gulp.src(src)
 							.pipe(prefixer(sassVar))
-							.pipe(sass({loadPath: ['.', 'bower_components'], style: 'compressed', sourcemap: false}))
+							.pipe(sass({loadPath: ['.', 'bower_components'], style: 'compressed', "sourcemap=none": true}))
 							.pipe(silentSass({silent: silent}))
 							.on('error', function(err) {
 								reject(err.message);


### PR DESCRIPTION
Works only with Sass 3.4

@alberto:

I see we're using `getCommandVersion('sass', '--version')` in `getInstalledSassGemVersion`.

It'd be great to make that reusable inside build.js and demo.js so that we can do something like:

```js
var sassVersion = getInstalledSassGemVersion();
if (semver.lt(sassVersion, '3.4')) {
  sassConfig["sourcemap=none"] = true;
}
```

And then this branch would work in both Sass 3.3 and 3.4.