### PR TITLE
Sass 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Runs:
 
 The versions that are installed and supported are:
 
-* Sass: '3.3.14' _(Sass 3.4.x is currently not supported and you may not get the desired result)_
-* scss-lint: '0.27.0'
+* Sass: '3.4.x'
+* scss-lint: '0.33.0'
 * JSHint: '2.5.6'
 * Bower: '1.3.12'
 

--- a/config/scss-lint.yml
+++ b/config/scss-lint.yml
@@ -1,36 +1,72 @@
 linters:
 
-  # ENABLED:
+  # Documentation:
+  # https://github.com/causes/scss-lint/blob/master/lib/scss_lint/linter/README.md
+
+  # "value !important;" not "value!important ;"
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+    severity: error
 
   # "border: 0" not "border: none"
   BorderZero:
     enabled: true
+    severity: error
 
-  # No capitals in selectors
-  CapitalizationInSelector:
-    enabled: true
+  # Allow colors to be used outside of variables
+  ColorVariable:
+    enabled: false
+
+  # "#0f0" not "green"
+  # (AB: Causes problems with o-colors < 3, because o-colors uses
+  # color names that are also valid CSS color strings)
+  ColorKeyword:
+    enabled: false
+
+  # // not /**/
+  Comment:
+    enabled: false
 
   # Disallow "@debug"
   DebugStatement:
     enabled: true
+    severity: error
 
   # @extend must come first, then properties, then nested rulesets
   DeclarationOrder:
     enabled: true
 
-  # Disallow use of the same property more than once in the same ruleset
+  # Warn when the same property appears more than once in the same ruleset
+  # This is not a deal breaker, as authors may repeat properties
+  # in the case where both a value and its fallback are needed
   DuplicateProperty:
     enabled: true
+
+  # "} else {" not "}\n else {"
+  ElsePlacement:
+    enabled: true
+    style: same_line # or 'new_line'
+
+  # Require an empty line between rulesets
+  EmptyLineBetweenBlocks:
+    enabled: false
+
+  # Disallow empty rulesets
+  EmptyRule:
+    enabled: false
 
   # Require a newline at the end of the file
   FinalNewline:
     enabled: true
     present: true
 
-  # #12346 good, #123 bad.
+  # #aabbcc good, #abc bad. Makes the codebase more searchable
   HexLength:
     enabled: true
     style: long
+    severity: error
 
   # Require hex colors to be lowercase (if they include any of the letters a-f)
   HexNotation:
@@ -41,78 +77,166 @@ linters:
   HexValidation:
     enabled: true
 
-  # Disallow combining of ID selectors with other selector tokens
-  IdWithExtraneousSelector:
+  # Disallow using ID Selectors
+  IdSelector:
     enabled: true
+
+  # "@import 'path/to/partial'" not "@import 'path/to/_partial.scss'"
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  # Avoid using !important
+  ImportantRule:
+    enabled: true
+
+  # Disable indentation liting since it's done via another task
+  Indentation:
+    enabled: false
 
   # 0.1 not .1
   # (differs from Guardian)
   LeadingZero:
     enabled: true
     style: include_zero
+    severity: error
+
+  # Disallow more than one ruleset with the same selector in the same file
+  MergeableSelector:
+    enabled: false
+
+  # Allow camelcase but forbid non-alphanumeric characters
+  # in mixin, variable and function names.
+  NameFormat:
+    enabled: true
+    convention: '^[a-zA-Z0-9_\-]+$'
+    severity: error
+
+  # Thou shall nest 3 levels deep maximum. Not 4, nor 5.
+  # See SelectorDepth for control over the actually maximum authorized depth
+  NestingDepth:
+    enabled: true
+    max_depth: 3
 
   # @extend %placeholders, don't @extend .a-class
   PlaceholderInExtend:
     enabled: true
+    severity: error
+
+  # Allow any number of properties in a ruleset
+  PropertyCount:
+    enabled: false
+
+  # Require properties to be in alphabetical order
+  # (also possible to specify a specific order)
+  # (AB: Alpha seems a bit weird. Rhys had a tool to do this,
+  # maybe we should set the order here and use this tool)
+  PropertySortOrder:
+    enabled: false
+    order: []
 
   # Disallow unknown CSS property names
   PropertySpelling:
     enabled: true
-    extra_properties: []
+    extra_properties:
+      - text-size-adjust
+
+  # ".class, [foo]" not "span.class, div[foo]"
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+    severity: error
+
+  # Limit selector depth
+  # (AB: We decided to deal with this via peer review in 
+  # https://github.com/Financial-Times/ft-origami/issues/243.
+  # If SCSS-lint were to support excluding sections of code,
+  # we could turn this back on (KDP:… as an error).
+  # Issue: https://github.com/causes/scss-lint/issues/150)
+  SelectorDepth:
+    enabled: true
+    max_depth: 3
+
+  # Allow lowercase only, but forbid non-alphanumeric characters
+  # in selector names.
+  SelectorFormat:
+    enabled: true
+    convention: '^[a-z0-9_\-]+$'
+    severity: error
 
   # margin: 1px not margin: 1px 1px 1px 1px;
   Shorthand:
     enabled: true
+    severity: error
+
+  # Disallow properties on the same line "margin: 0; padding: 0;"
+  SingleLinePerProperty:
+    enabled: true
+    # enable simple rules to be on a single line "el { margin: 0; }"
+    allow_single_line_rule_sets: true
+    severity: error
+
+  # Rulesets with multiple (comma delimited) selectors
+  # must have each selector on a separate line
+  SingleLinePerSelector:
+    enabled: true
+    severity: error
 
   # rgb(0, 0, 0) not rgb(0,0,0)
   SpaceAfterComma:
     enabled: true
+    severity: error
 
   # margin: 0px not margin:0px
   SpaceAfterPropertyColon:
     enabled: true
+    style: one_space
+    severity: error
 
   # margin: 0px not margin : 0px
   # (AB: clearly this should be called NoSpaceAfterPropertyName)
   SpaceAfterPropertyName:
     enabled: true
+    severity: error
 
   # .thing { not .thing{
   SpaceBeforeBrace:
     enabled: true
+    style: space
     allow_single_line_padding: false
+    severity: error
 
-  # rgb(0,0,0) not rgb( 0,0,0 )
+  # rgb(0, 0, 0) not rgb( 0, 0, 0 )
   SpaceBetweenParens:
     enabled: true
     spaces: 0
-
-  # Every property value must end with a semicolon
-  TrailingSemicolon:
-    enabled: true
-
-  # No unnecessary fractions: 1 not 1.0
-  UnnecessaryMantissa:
-    enabled: true
-
-
-
-  # DISABLED
-
-  # "#0f0" not "green"
-  # (AB: Causes problems with o-colors < 3, because o-colors uses color names that are also valid CSS color strings)
-  ColorKeyword:
-    enabled: false
-
-  # // not /**/
-  # (differs from Guardian)
-  Comment:
-    enabled: false
+    severity: error
 
   # Use single quotes, not double quotes
   # (AB: This really doesn't matter IMHO)
   # Differs from guardian
   StringQuotes:
+    enabled: false
+
+  # Every property value must end with a semicolon
+  TrailingSemicolon:
+    enabled: true
+    severity: error
+
+  # "margin: .5em;" not "margin: .500em;"
+  TrailingZero:
+    enabled: true
+
+  # No unnecessary fractions: 1 not 1.0
+  UnnecessaryMantissa:
+    enabled: true
+    severity: error
+
+  # Disable this rule to allow parent references such as "& + * {}"
+  UnnecessaryParentReference:
     enabled: false
 
   # URLs must not contain domain names
@@ -124,47 +248,20 @@ linters:
   UrlQuotes:
     enabled: false
 
+  # Allow any property to have literal values
+  VariableForProperty:
+    enabled: false
+
+  # Allow vendor prefixes
+  # (…by disabling the linter that forbids vendor prefixes)
+  # But: ideally products should use autoprefixer or equivalent,
+  # since we might eventually enable this linter.
+  VendorPrefixes:
+    enabled: true
+    severity: warning
+
   # No units on zero values: 0 not 0px
-  # (AB: it can be useful to express what unit you want something to be in if its value is ever adjusted away from zero)
+  # (AB: it can be useful to express what unit you want
+  # something to be in if its value is ever adjusted away from zero)
   ZeroUnit:
     enabled: false
-
-  # Require an empty line between rulesets
-  EmptyLineBetweenBlocks:
-    enabled: false
-
-  # Disallow more than one ruleset with the same selector in the same file
-  MergeableSelector:
-    enabled: false
-
-  # Disallow empty rulesets
-  EmptyRule:
-    enabled: false
-
-  # Require spaces for indentation
-  # (AB: Absolutely not.  Revelation: tabs are designed to indent stuff)
-  # (differs from Guardian)
-  Indentation:
-    enabled: false
-
-  # Disallow camelcase and enforce BEM standards
-  # (AB: we have exceptions, we use camel for mixins and functions)
-  NameFormat:
-    enabled: false
-    convention: BEM
-
-  # Require properties to be in alphabetical order (also possible to specify a specific order)
-  # (AB: Alpha seems a bit weird.  Rhys had a tool to do this, maybe we should set the order here and use this tool)
-  PropertySortOrder:
-    enabled: false
-    order: []
-
-  # Rulesets with multiple (comma delimited) selectors must have each selector on a separate line
-  SingleLinePerSelector:
-    enabled: false
-
-  # Limit selector depth
-  # (AB: We decided to deal with this via peer review in https://github.com/Financial-Times/ft-origami/issues/243.  If SCSS-lint were to support excluding sections of code, we could turn this back on.  Issue: https://github.com/causes/scss-lint/issues/150)
-  SelectorDepth:
-    enabled: false
-    max_depth: 3

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -91,7 +91,9 @@ module.exports.sass = function(gulp, config) {
 		config.env = config.env || 'development';
 
 		var sassConfig = {
-			loadPath: ['.', 'bower_components']
+			loadPath: ['.', 'bower_components'],
+			// Hack: we're waiting for gulp-ruby-sass v1 to be released, with better support for soucemaps
+			"sourcemap=none": true
 		};
 
 		var autoprefixerConfig = {
@@ -103,15 +105,6 @@ module.exports.sass = function(gulp, config) {
 		if (config.env === 'production') {
 			sassConfig.style = 'compressed';
 		}
-		// Sourcemaps aren't compatible with csso, we'll look for a work-around when gulp-ruby-sass 1.0 is released
-		// in the time being, we disable them explicitly
-		sassConfig.sourcemap = false;
-		// if (config.sourcemap) {
-		//     sassConfig.sourcemap = config.sourcemap;
-		// }
-		// if (config.sourcemapPath) {
-		//     sassConfig.sourcemapPath = config.sourcemapPath;
-		// }
 		return gulp.src(src)
 			.pipe(sass(sassConfig))
 			.on('error', function(err) { throw err; })

--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -42,7 +42,12 @@ function buildSass(gulp, demoConfig) {
 			gulp.src(src)
 				.pipe(prefixer(prefixSass))
 				// For the Sass files to load correctly, they need to be in one of these two directories. Sass doesn't look in subdirectories and we can't use wildcards
-				.pipe(sass({loadPath: ['demos/src', 'demos/src/scss', 'bower_components'], style: 'compressed'}))
+				.pipe(sass({
+					loadPath: ['demos/src', 'demos/src/scss', 'bower_components'],
+					style: 'compressed',
+					// Hack: we're waiting for gulp-ruby-sass v1 to be released, with better support for soucemaps
+					"sourcemap=none": true
+				}))
 				.on('error', reject)
 				.pipe(autoprefixer({browsers: ['> 1%', 'last 2 versions', 'ie > 6', 'ff ESR'], cascade: false}))
 				.pipe(gulp.dest(dest))

--- a/lib/tasks/install.js
+++ b/lib/tasks/install.js
@@ -9,8 +9,8 @@ var commandLine = require('../helpers/command-line');
 var files = require('../helpers/files');
 
 var versions = {
-	sass: '3.3.14',
-	scssLint: '0.27.0',
+	sass: '3.4.10',
+	scssLint: '0.33.0',
 	JSHint: '2.5.6',
 	bower: '1.3.12'
 };

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -19,7 +19,7 @@ function silentCompilationTest(gulp, silent) {
 						var sassVar = '$' + files.getBowerJson().name + '-is-silent: ' + silent + ';\n';
 						gulp.src(src)
 							.pipe(prefixer(sassVar))
-							.pipe(sass({loadPath: ['.', 'bower_components'], style: 'compressed', sourcemap: false}))
+							.pipe(sass({loadPath: ['.', 'bower_components'], style: 'compressed', "sourcemap=none": true}))
 							.pipe(silentSass({silent: silent}))
 							.on('error', function(err) {
 								reject(err.message);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-ruby-sass": "^0.7.1",
     "gulp-sassdoc": "^1.1.1",
-    "gulp-scss-lint": "^0.1.5",
+    "gulp-scss-lint": "^0.1.6",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-ruby-sass": "^0.7.1",
     "gulp-sassdoc": "^1.1.1",
-    "gulp-scss-lint": "^0.1.3",
+    "gulp-scss-lint": "^0.1.5",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",


### PR DESCRIPTION
Feel free to use the build tools with this branch. I've been using it for two weeks and it worked well so far.

The main benefit is that we can now use scss-lint's `scss-lint:disable` flag, such as:

```scss
	// scss-lint:disable SelectorDepth
	[data-o-hierarchical-nav-level='1'] {
		> li > a {
			line-height: 25px;
			max-height: 25px;
		}

		// Set styling for selected and hovered a tags
		[aria-selected="true"] a,
		[aria-controls][aria-expanded="true"] a,
		#{$o-hoverable-if-hover-enabled} & > li > a:hover {
			background-color: $_o-header-secondary-selected;
			color: oColorsGetColorFor(link-title, text);
			opacity: 1;
		}
	}
	// scss-lint:enable SelectorDepth
```

https://github.com/Financial-Times/o-ft-header/blob/3.0.0-beta.3/src/scss/nav/theme-secondary.scss#L20