### PR TITLE
changing order of browserify transforms

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -33,7 +33,7 @@ module.exports.js = function(gulp, config) {
 	config = config || {};
 	var src = config.js || files.getMainJsPath() || null;
 	if (src) {
-		var transforms = ['debowerify', 'textrequireify', '6to5ify'].concat(config.transforms || []);
+		var transforms = ['6to5ify', 'debowerify', 'textrequireify'].concat(config.transforms || []);
 		delete config.transforms;
 
 		// Hackily shallow clone the config object


### PR DESCRIPTION
Debowerify uses esprima to parse the code which doesn't (yet) support ES6, so 6to5 needs to run first