### PR TITLE
Update to latest version of Sass

### DIFF
--- a/lib/tasks/install.js
+++ b/lib/tasks/install.js
@@ -9,7 +9,7 @@ var commandLine = require('../helpers/command-line');
 var files = require('../helpers/files');
 
 var versions = {
-	sass: '3.4.12',
+	sass: '3.4.13',
 	scssLint: '0.34.0',
 	JSHint: '2.5.6',
 	bower: '1.3.12'


### PR DESCRIPTION
### Sass 3.4.13 (26 February 2015)

- Be clearer in the reference about hyphen/underscore equivalence.
- @keyframes rules are now converted from CSS properly.
- Extending a selector that contains a non-final pseudo-class no longer crashes.
- When @extending, only a single :root element will be retained.