### PR TITLE
Undo `--loglevel info`

### DIFF
--- a/lib/tasks/install.js
+++ b/lib/tasks/install.js
@@ -238,9 +238,9 @@ module.exports.runNpmInstall = function(config) {
 		args.push(['--registry '+config.registry]);
 	}
 
-	if (config.verbose) {
-		args.push(['--loglevel info']);
-	}
+//	if (config.verbose) {
+//		args.push(['--loglevel info']);
+//	}
 
 	if (files.packageJsonExists()) {
 		commandLine.run('npm', args, { stderr: 'pipe', stdout: 'pipe' })


### PR DESCRIPTION
This is breaking all builds of this version of OBT on Next…  (seriously)

![screen shot 2015-03-05 at 16 58 01](https://cloud.githubusercontent.com/assets/825088/6509865/1dc987f6-c35a-11e4-8ff9-230cc0fb8717.png)
