### PR TITLE
#perfmatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,5 +205,16 @@ npm install --save-dev gulp
 npm install -g gulp
 ```
 
+
+The `origami-build-tools` module also defines some helper methods to verify and list the available tasks:
+
+`obt.isValid(taskName)` will return a boolean value indicating whether the
+name of the given task is valid.
+
+`obt.list()` will return a list of valid task names.
+
+`obt.loadAll()` will return an object with all of the available tasks loaded onto it.
+Access tasks on this object as properties in the same way as the `obt` object.
+
 ## Licence
 This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/lib/helpers/log.js
+++ b/lib/helpers/log.js
@@ -2,6 +2,14 @@
 
 require('colors');
 
+var debugLog = function() {};
+
+if (process.env.DEBUG === "true") {
+	debugLog = function(text) {
+		console.log(String(text).grey);
+	};
+}
+
 module.exports = {
 
 	primary: function(text) {
@@ -15,6 +23,8 @@ module.exports = {
 	secondary: function(text) {
 		console.log(String(text).grey);
 	},
+
+	debug: debugLog,
 
 	secondaryError: function(text) {
 		console.log(String(text).red);

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -65,7 +65,7 @@ var watch = !!argv.watch,
 	argument = argv._[0];
 
 if (tasks.isValid(argument)) {
-	var task = tasks.load(argument);
+	var task = tasks[argument];
 
 	if (watch && task.watchable) {
 		watcher.run(task, gulp, argv);

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -64,8 +64,8 @@ if (argv.version) {
 var watch = !!argv.watch,
 	argument = argv._[0];
 
-if (tasks.hasOwnProperty(argument)) {
-	var task = tasks[argument];
+if (tasks.isValid(argument)) {
+	var task = tasks.load(argument);
 
 	if (watch && task.watchable) {
 		watcher.run(task, gulp, argv);
@@ -77,6 +77,6 @@ if (tasks.hasOwnProperty(argument)) {
 		log.primaryError(argument + ' is not a valid command');
 	}
 
-	printUsage(tasks);
+	printUsage(tasks.loadAll());
 	process.exit(2);
 }

--- a/lib/origami-build-tools.js
+++ b/lib/origami-build-tools.js
@@ -5,25 +5,42 @@ require('es6-promise').polyfill();
 var update = require('./helpers/update-notifier');
 var log = require('./helpers/log');
 update();
+var tasks = {
+	'install': './tasks/install',
+	'build': './tasks/build',
+	'demo': './tasks/demo',
+	'verify': './tasks/verify',
+	'test': './tasks/test',
+	'docs': './tasks/docs',
+	'--version': './tasks/version'
+};
 
 function TaskLoader() {
-	this.tasks = {
-		'install': './tasks/install',
-		'build': './tasks/build',
-		'demo': './tasks/demo',
-		'verify': './tasks/verify',
-		'test': './tasks/test',
-		'docs': './tasks/docs',
-		'--version': './tasks/version'
-	};
+	this.tasks = tasks;
+	this.taskCache = {};
 }
+
+// For backwards compatibility allow access of each task via a property of the
+// TaskLoader
+Object.keys(tasks).forEach(function(task) {
+	Object.defineProperty(TaskLoader.prototype, task, {
+		get: function() {
+			return this.load(task);
+		}
+	});
+});
 
 
 TaskLoader.prototype.load = function(taskName) {
+	if (this.taskCache.hasOwnProperty(taskName)) {
+		return this.taskCache[taskName];
+	}
+
 	var startTime = process.hrtime();
 	var module = require(this.tasks[taskName]);
 	var timeTaken = process.hrtime(startTime);
 	log.debug("Loaded task: " + taskName + " in " + timeTaken.join(".") + "s");
+	this.taskCache[taskName] = module;
 	return module;
 };
 

--- a/lib/origami-build-tools.js
+++ b/lib/origami-build-tools.js
@@ -3,6 +3,7 @@
 require('es6-promise').polyfill();
 
 var update = require('./helpers/update-notifier');
+var log = require('./helpers/log');
 update();
 
 function TaskLoader() {
@@ -19,14 +20,16 @@ function TaskLoader() {
 
 
 TaskLoader.prototype.load = function(taskName) {
+	var startTime = process.hrtime();
 	var module = require(this.tasks[taskName]);
+	var timeTaken = process.hrtime(startTime);
+	log.debug("Loaded task: " + taskName + " in " + timeTaken.join(".") + "s");
 	return module;
-}
+};
 
 TaskLoader.prototype.isValid = function(taskName) {
 	return this.tasks.hasOwnProperty(taskName);
-
-}
+};
 
 TaskLoader.prototype.list = function() {
 	return Object.keys(this.tasks);

--- a/lib/origami-build-tools.js
+++ b/lib/origami-build-tools.js
@@ -3,24 +3,41 @@
 require('es6-promise').polyfill();
 
 var update = require('./helpers/update-notifier');
-var verifier = require('./tasks/verify');
-var installer = require('./tasks/install');
-var builder = require('./tasks/build');
-var tester = require('./tasks/test');
-var demoer = require('./tasks/demo');
-var docs = require('./tasks/docs');
-var version = require('./tasks/version');
-
 update();
 
-var tasks = {
-	'install': installer,
-	'build': builder,
-	'demo': demoer,
-	'verify': verifier,
-	'test': tester,
-	'docs': docs,
-	'--version': version
+function TaskLoader() {
+	this.tasks = {
+		'install': './tasks/install',
+		'build': './tasks/build',
+		'demo': './tasks/demo',
+		'verify': './tasks/verify',
+		'test': './tasks/test',
+		'docs': './tasks/docs',
+		'--version': './tasks/version'
+	};
+}
+
+
+TaskLoader.prototype.load = function(taskName) {
+	var module = require(this.tasks[taskName]);
+	return module;
+}
+
+TaskLoader.prototype.isValid = function(taskName) {
+	return this.tasks.hasOwnProperty(taskName);
+
+}
+
+TaskLoader.prototype.list = function() {
+	return Object.keys(this.tasks);
 };
 
-module.exports = tasks;
+TaskLoader.prototype.loadAll = function() {
+	var loader = this;
+	return this.list().reduce(function(modules, module) {
+		modules[module] = loader.load(module);
+		return modules;
+	}, {});
+};
+
+module.exports = new TaskLoader();

--- a/lib/origami-build-tools.js
+++ b/lib/origami-build-tools.js
@@ -5,31 +5,29 @@ require('es6-promise').polyfill();
 var update = require('./helpers/update-notifier');
 var log = require('./helpers/log');
 update();
-var tasks = {
-	'install': './tasks/install',
-	'build': './tasks/build',
-	'demo': './tasks/demo',
-	'verify': './tasks/verify',
-	'test': './tasks/test',
-	'docs': './tasks/docs',
-	'--version': './tasks/version'
-};
 
 function TaskLoader() {
-	this.tasks = tasks;
+	this.tasks = {
+		'install': './tasks/install',
+		'build': './tasks/build',
+		'demo': './tasks/demo',
+		'verify': './tasks/verify',
+		'test': './tasks/test',
+		'docs': './tasks/docs',
+		'--version': './tasks/version'
+	};
+
 	this.taskCache = {};
-}
 
-// For backwards compatibility allow access of each task via a property of the
-// TaskLoader
-Object.keys(tasks).forEach(function(task) {
-	Object.defineProperty(TaskLoader.prototype, task, {
-		get: function() {
-			return this.load(task);
-		}
+	// Allow access of each task via a property of the TaskLoader
+	Object.keys(this.tasks).forEach(function(task) {
+		Object.defineProperty(TaskLoader.prototype, task, {
+			get: function() {
+				return this.load(task);
+			}
+		});
 	});
-});
-
+}
 
 TaskLoader.prototype.load = function(taskName) {
 	if (this.taskCache.hasOwnProperty(taskName)) {
@@ -54,8 +52,8 @@ TaskLoader.prototype.list = function() {
 
 TaskLoader.prototype.loadAll = function() {
 	var loader = this;
-	return this.list().reduce(function(modules, module) {
-		modules[module] = loader.load(module);
+	return this.list().reduce(function(modules, task) {
+		modules[task] = loader.load(task);
 		return modules;
 	}, {});
 };


### PR DESCRIPTION
Introduce a TaskLoader for loading tasks.
Introduce a new log level 'debug' (which is defaulted to 'off').  To turn it on run `DEBUG=true obt task`.

The main reason to introduce the DEBUG=true log level is to surface performance issues and help spot issues, if any are low hanging fruit, and easy to fix, we can fix them in the right place.