### PR TITLE
Update browserify dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,8 @@ Runs:
 	- env: `String` It can be either 'production' or 'development'. If it's 'production', it will run [uglify](https://github.com/mishoo/UglifyJS2). If it's 'development', it will generate a sourcemap. (Default: 'development')
 	- sourcemaps: `Boolean` Set to true to output sourcemaps, even if env is 'development'. (Default: false)
 	- hash: `Boolean` Set to true to generate a hashed JavaScript built file to facilitate cachebusting. Also generates a JSON file with mappings to the original filename. (Default: false)
-	- transforms: `Array` Additional browserify transforms to run *after* debowerify and textrequireify. Each transform should be specified as one of the following
-		- `String` The name of the transform
-		- `Array` [config, 'transform-name'] Where custom config needs to be passed into the transform use an array containing the config object followed by the transform name
-		- `Object` Some transforms require passing in a single object which both specifies and configures the transform
+	- transforms: `Array` Additional browserify transforms to run *after* debowerify and textrequireify. Each transform should be specified as a function
+		- `Function` The transform function.  e.g:  `var brfs = require('brfs'); config.transform.push(brfs);`
 	- insertGlobals: See [browserify documentation](https://github.com/substack/node-browserify#usage)
 	- detectGlobals: See [browserify documentation](https://github.com/substack/node-browserify#usage)
 	- ignoreMissing: See [browserify documentation](https://github.com/substack/node-browserify#usage)

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -14,6 +14,10 @@ var files = require('../helpers/files');
 var log = require('../helpers/log');
 var hash = require('gulp-hash');
 
+var textrequireify = require('textrequireify');
+var debowerify = require('debowerify');
+var babelify = require('babelify');
+
 var hashOptions = {
 	algorithm: 'sha1',
 	hashLength: 10,
@@ -33,19 +37,11 @@ module.exports.js = function(gulp, config) {
 	config = config || {};
 	var src = config.js || files.getMainJsPath() || null;
 	if (src) {
-		var transforms = ['babelify', 'debowerify', 'textrequireify'].concat(config.transforms || []);
-		delete config.transforms;
-
-		// Hackily shallow clone the config object
-		config = Object.keys(config).reduce(function(newConfig, current) {
-			newConfig[current] = config[current];
-			return newConfig;
-		}, {});
+		// See; https://github.com/substack/node-browserify#btransformtr-opts
+		var transforms = [babelify, debowerify, textrequireify].concat(config.transforms || []);
 
 		var useSourceMaps = config.sourcemaps === true;
-
 		config.env = config.env || 'development';
-
 		config.debug = useSourceMaps || config.env === 'development';
 
 		var destFolder = config.buildFolder || files.getBuildFolderPath();
@@ -53,23 +49,15 @@ module.exports.js = function(gulp, config) {
 
 		log.secondary("Browserifying " + src);
 
-		var bundle = browserify(src)
-			.require(src, {});
+		var bundle = browserify(config)
+			.add(src)
+			.require(src, { entry: true });
 
-		transforms.forEach(function(transform) {
-			// the usual use case - most of the time transforms work without needing any custom config
-			if (typeof transform === 'string') {
-				bundle.transform({}, transform);
-			// sometimes a config option is needed too, in which case the user will pass in an array [config, 'transform-name']
-			} else if (transform.length === 2) {
-				bundle.transform.apply(bundle, transform);
-			// some transforms use a seemingly undocumented (deprecated?) API where they pass in an object generated using the transform's own js API
-			} else {
-				bundle.transform(transform);
-			}
-		});
+		bundle = transforms.reduce(function(bundle, transform) {
+			return bundle.transform(transform);
+		}, bundle);
 
-		return bundle.bundle(config)
+		return bundle.bundle()
 			.pipe(source(dest))
 			.pipe(gulpif(config.env === 'production', streamify(uglify())))
 			.pipe(gulpif(config.hash === true, streamify(hash(hashOptions))))

--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -13,6 +13,10 @@ var extend = require('node.extend');
 var prefixer = require('../plugins/gulp-prefixer.js');
 var log = require('../helpers/log.js');
 var files = require('../helpers/files.js');
+var textrequireify = require('textrequireify');
+var debowerify = require('debowerify');
+var babelify = require('babelify');
+
 var builtFiles = {};
 var defaultDemoConfig = {
 	bodyClasses: "",
@@ -71,13 +75,16 @@ function buildJs(gulp, demoConfig) {
 			}
 			log.secondary("Browserifying: " + demoConfig.js);
 			builtFiles.js.push(src);
-			browserify(src)
+
+			// TODO: Maybe reuse tasks.build.js?
+			browserify({debug: true})
 				.on('error', reject)
-				.require(src, {})
-				.transform({}, 'debowerify')
-				.transform({}, 'textrequireify')
-				.transform({}, 'babelify')
-				.bundle({debug: true})
+				.add(src)
+				.require(src, { entry: true })
+				.transform(debowerify)
+				.transform(textrequireify)
+				.transform(babelify)
+				.bundle()
 				.pipe(source(dest))
 				.pipe(gulp.dest(destFolder))
 				.on('end', function() {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "browserify": "^9.0.0",
     "colors": "^0.6.2",
     "configstore": "^0.3.1",
-    "debowerify": "Financial-Times/debowerify",
+    "debowerify": "^1.2.0",
     "es6-promise": "^1.0.0",
     "findit": "^1.1.1",
     "gulp": "^3.8.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "babelify": "^5.0.3",
     "bower-config": "^0.5.2",
-    "browserify": "~3.44.2",
+    "browserify": "^9.0.0",
     "colors": "^0.6.2",
     "configstore": "^0.3.1",
     "debowerify": "Financial-Times/debowerify",
@@ -44,7 +44,7 @@
     "portfinder": "0.2.x",
     "sassdoc": "^2.1.2",
     "semver": "^2.2.1",
-    "textrequireify": "^1.0.0",
+    "textrequireify": "samgiles/textrequireify",
     "through2": "^0.6.2",
     "vinyl-source-stream": "^1.0.0",
     "which": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "portfinder": "0.2.x",
     "sassdoc": "^2.1.2",
     "semver": "^2.2.1",
-    "textrequireify": "samgiles/textrequireify",
+    "textrequireify": "^2.0.1",
     "through2": "^0.6.2",
     "vinyl-source-stream": "^1.0.0",
     "which": "^1.0.5"


### PR DESCRIPTION
This has a dependency on a fork of `textrequireify`, waiting for that to get merged and published to NPM.  Don't merge before I've updated the `package.json` here for it.

This is a breaking change as it alters the API for configuring browserify transforms.


