### PR TITLE
Update to latest version of SCSS-Lint and allow vendor prefixes for certain properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Runs:
 The versions that are installed and supported are:
 
 * Sass: '^3.4.0'
-* scss-lint: '0.34.0'
+* scss-lint: '0.35.0'
 * JSHint: '^2.5.0'
 * Bower: '^1.3.0'
 

--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -28,7 +28,7 @@ This can be fixed by following the [Installing Ruby steps](#installing-ruby) men
 If the error still occurs, run the command manually by prefixing sudo to it. It's the following command (substituting the version number by the one mentioned [here](https://github.com/Financial-Times/origami-build-tools/#install)):
 
 ```bash
-sudo gem install scss-lint -v 0.34.0
+sudo gem install scss-lint -v 0.35.0
 sudo gem install sass -v 3.4.0
 ```
 

--- a/config/scss-lint.yml
+++ b/config/scss-lint.yml
@@ -252,12 +252,14 @@ linters:
   VariableForProperty:
     enabled: false
 
-  # Allow vendor prefixes
-  # (…by disabling the linter that forbids vendor prefixes)
-  # But: ideally products should use autoprefixer or equivalent,
+  # No vendor prefixes
+  # Ideally products should use autoprefixer or equivalent,
   # since we might eventually enable this linter.
-  VendorPrefixes:
+  VendorPrefix:
     enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: ["user-select", "appearance", "font-smoothing", "osx-font-smoothing"]
     severity: warning
 
   # No units on zero values: 0 not 0px

--- a/lib/tasks/install.js
+++ b/lib/tasks/install.js
@@ -14,7 +14,7 @@ var files = require('../helpers/files');
 // to install patches
 var bestGems = {
 	sass: '3.4.13',
-	scssLint: '0.34.0'
+	scssLint: '0.35.0'
 };
 
 var versions = {


### PR DESCRIPTION
Thanks to the latest version of SCSS-Lint, we can exclude certain non-standard properties that require vendor-prefixes so that they won't raise warnings anymore:
- user-select
- font-smoothing

Fixes https://github.com/Financial-Times/ft-origami/issues/343