### PR TITLE
Go back to using the official scss-lint gulp task

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-mustache": "^1.0.2",
     "gulp-rename": "^1.2.0",
     "gulp-ruby-sass": "^1.0.1",
-    "gulp-scss-lint": "samgiles/gulp-scss-lint#v1.0.0",
+    "gulp-scss-lint": "^0.1.12",
     "gulp-sourcemaps": "^1.5.1",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^1.0.1",


### PR DESCRIPTION
It now uses [sync-exec](https://www.npmjs.com/package/sync-exec), an fs.execSync replacement until you get it natively from node 0.12+.

@samgiles I think your fork is better than this version but I believe it's probably better to follow the main project instead of relying on our own forks.