### PR TITLE
Suppress stderr when getting the version of a command

### DIFF
--- a/lib/tasks/install.js
+++ b/lib/tasks/install.js
@@ -56,7 +56,7 @@ function getInstalledBowerVersion() {
 
 function getCommandVersion(command, versionFlag) {
 	return new Promise(function(resolve, reject) {
-		commandLine.run(command, [versionFlag, '2>&1'])
+		commandLine.run(command, [versionFlag, '2>/dev/null'])
 			.then(function(output) {
 				var re = new RegExp(/\d+(\.\d+)+/);
 				var version = output.stdout.trim().match(re);


### PR DESCRIPTION
I can't think of a case where wanting the stderr of a `--version` call would ever be useful……

Also because ruby is corrupted on Next's Jenkins machine (cc @captain-sysadmin) this means OBT doesn't work for any of our Stash repos :-(.