### PR TITLE
let npm publish obt with `.eslintrc`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .idea/
 test/
 *.md
-.eslintrc
 gulpfile.js
 .travis.yml


### PR DESCRIPTION
I don't think you tested this :-)

if you try to do `obt verify` you get this error:-

```
/Users/mandrews/sandboxes/next-build-tools/node_modules/origami-build-tools/node_modules/gulp-eslint/node_modules/eslint/lib/config.js:78
                throw e;
                      ^
Error: Cannot read config file: /Users/mandrews/sandboxes/next-build-tools/node_modules/origami-build-tools/config/.eslintrc
Error: ENOENT, no such file or directory '/Users/mandrews/sandboxes/next-build-tools/node_modules/origami-build-tools/config/.eslintrc
```

because `.npmignore` is stopping that file from being published to the registry