### PR TITLE
Allow Bower Plugin to resolve default bower_components directory

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -58,12 +58,21 @@ module.exports.js = function(gulp, config) {
 		const destFolder = config.buildFolder || files.getBuildFolderPath();
 		const dest = config.buildJs || 'main.js';
 
+		const bowerPlugin = new BowerPlugin({
+			includes: /\.js$/
+		});
+
+		// Since (currently) no custom module directories are defined, rely on BowerPlugin dir resolution.
+		const moduleDirectories = bowerPlugin.modulesDirectories.map((moduleDirectory) => {
+			return path.join(cwd, moduleDirectory);
+		});
+
 		log.secondary('Webpacking ' + src);
 
 		const webpackConfig = {
 			quiet: true,
 			resolve: {
-				root: [path.join(cwd, 'bower_components')]
+				root: moduleDirectories
 			},
 			resolveLoader: {
 				root: [
@@ -76,9 +85,7 @@ module.exports.js = function(gulp, config) {
 				}
 			},
 			plugins: [
-				new BowerPlugin({
-					includes:  /\.js$/
-				})
+				bowerPlugin
 			],
 			module: {
 				loaders: [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.6.15",
     "bower-config": "^0.6.1",
-    "bower-webpack-plugin": "^0.1.8",
+    "bower-webpack-plugin": "^0.1.9",
     "colors": "^1.1.2",
     "configstore": "^1.1.0",
     "denodeify": "^1.2.1",


### PR DESCRIPTION
Re-doing #310 against master, since updating it with ES6 has led to a very messy thread.

Essentially this is for the purpose of allowing lpiepiora/bower-webpack-plugin#27 to handle the resolution directory for OBT, so that custom module directories are respected.