### PR TITLE
Preserve autoprefixer comments

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -148,7 +148,7 @@ module.exports.sass = function(gulp, config) {
 
 		const sassConfig = {
 			includePaths: [path.join(cwd, 'bower_components')].concat(config.sassIncludePaths || []),
-			outputStyle: config.env === 'production' ? 'compressed' : 'nested'
+			outputStyle: 'nested'
 		};
 
 		const autoprefixerConfig = {


### PR DESCRIPTION
If sass outputs compressed then any autoprefixer comments are stripped out. This change outputs verbose css from sass. As cssclean runs after autoprefixer the css does end up getting minified anyway.

As a small bonus, this will probably make the build slightly quicker