### PR TITLE
Explicitly require babel-core peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "mocha -t 50000 `find . -name '*.test.js' -path './test/*'`"
   },
   "dependencies": {
+    "babel-core": "^5.8.34",
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.6.15",
     "bower-config": "^0.6.1",


### PR DESCRIPTION
`babel-core` is a peer dependency of `babel-loader`, and as per what's recommended in npm v2 (and required in v3), can we explicitly depend on it