### PR TITLE
fix error when no JS or Sass streams are returned

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -21,12 +21,18 @@ module.exports = function(gulp, config) {
 	const buildStream = merge();
 	const emitBuildStreamErrorEvent = buildStream.emit.bind(buildStream, 'error');
 	if (typeof config.watching === 'undefined' || config.watching === 'js') {
-		jsStream = module.exports.js(gulp, config)
-			.on('error', emitBuildStreamErrorEvent);
+		jsStream = module.exports.js(gulp, config);
+
+		if (typeof jsStream !== 'undefined') {
+			jsStream.on('error', emitBuildStreamErrorEvent);
+		}
 	}
 	if (typeof config.watching === 'undefined' || config.watching === 'sass') {
-		sassStream = module.exports.sass(gulp, config)
-			.on('error', emitBuildStreamErrorEvent);
+		sassStream = module.exports.sass(gulp, config);
+
+		if (typeof sassStream !== 'undefined') {
+			sassStream.on('error', emitBuildStreamErrorEvent);
+		}
 	}
 	if (jsStream && sassStream) {
 		buildStream.add(jsStream, sassStream);


### PR DESCRIPTION
Error occurs when no JS or Sass stream is returned. Check if stream returned is not `undefined` before assigning the event handler.