### PR TITLE
Optionally allow failed browser tests to fail CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Runs:
 * __silentCompilation(gulp)__ Test [silent compilation](http://origami.ft.com/docs/syntax/scss/#silent-styles). Check the Sass outputs no CSS by default. Only ran af a `$<module-name>-is-silent` variable is found
 * __silentCompilation(gulp)__ Test [silent compilation](http://origami.ft.com/docs/syntax/scss/#silent-styles). Check the Sass outputs some CSS with `$<module-name>-is-silent` set to false. Only ran af a `$<module-name>-is-silent` variable is found
 * __npmTest()__ Runs 'npm test', so whatever test script that you have in you `package.json` will be executed
-* __browserTest(gulp, config)__ Runs [Nightwatch](http://nightwatchjs.org/) tests on our [Selenium](http://www.seleniumhq.org/projects/webdriver/) grid by deploying the demo pages to Heroku. This is an optional subtask that requires the config option _browserTest_ to be set to true. By default the failed browser tests will not fail the task, however you can override the default behaviour by setting _browserTestFailBuild_ config option to true. You also need to set the following environment variables:
+* __browserTest(gulp, config)__ Runs [Nightwatch](http://nightwatchjs.org/) tests on our [Selenium](http://www.seleniumhq.org/projects/webdriver/) grid by deploying the demo pages to Heroku. This is an optional subtask that requires the config option _browserTest_ to be set to true. You also need to set the following environment variables:
 	- HEROKU_AUTH_TOKEN: The result of running `heroku auth:token`
 	- SELENIUM_USER: The username of the Selenium grid proxy
 	- SELENIUM_KEY: The key to use the proxy to the Selenium grid
@@ -165,6 +165,7 @@ Config accepts:
 	- nightwatchConfig: `String` Path to your 'nightwatch.json' file that Nightwatch uses for testing. (Default: `./test/browser/nightwatch.json`)
 	- environments: `String` Comma separated list of environments from your nightwatch config file to run your tests on. (Default: `chrome_latest,chrome_latest-1,firefox_latest,firefox_latest-1,ie8_Grid,ie9_Grid,ie10_Grid,ie11_Grid,safari7_Grid`)
 	- testsPath: `String` Relative path from your project's root directory to where your nightwatch tests are. (Default: `test/browser/tests`)
+	- browserTestFailBuild: `Boolean` by default the failed browser tests will not fail the task, however you can override the default behaviour by setting this option to `true`. Default: `false`
 
 ## gulpfile usage
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Runs:
 * __silentCompilation(gulp)__ Test [silent compilation](http://origami.ft.com/docs/syntax/scss/#silent-styles). Check the Sass outputs no CSS by default. Only ran af a `$<module-name>-is-silent` variable is found
 * __silentCompilation(gulp)__ Test [silent compilation](http://origami.ft.com/docs/syntax/scss/#silent-styles). Check the Sass outputs some CSS with `$<module-name>-is-silent` set to false. Only ran af a `$<module-name>-is-silent` variable is found
 * __npmTest()__ Runs 'npm test', so whatever test script that you have in you `package.json` will be executed
-* __browserTest(gulp, config)__ Runs [Nightwatch](http://nightwatchjs.org/) tests on our [Selenium](http://www.seleniumhq.org/projects/webdriver/) grid by deploying the demo pages to Heroku. This is an optional subtask that requires the config option _browserTest_ to be set to true. You also need to set the following environment variables:
+* __browserTest(gulp, config)__ Runs [Nightwatch](http://nightwatchjs.org/) tests on our [Selenium](http://www.seleniumhq.org/projects/webdriver/) grid by deploying the demo pages to Heroku. This is an optional subtask that requires the config option _browserTest_ to be set to true. By default the failed browser tests will not fail the task, however you can override the default behaviour by setting _browserTestFailBuild_ config option to true. You also need to set the following environment variables:
 	- HEROKU_AUTH_TOKEN: The result of running `heroku auth:token`
 	- SELENIUM_USER: The username of the Selenium grid proxy
 	- SELENIUM_KEY: The key to use the proxy to the Selenium grid

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -208,7 +208,7 @@ module.exports.browserTest = function(gulp, config) {
 			token: token,
 			app: appName
 			// Suppress any errors
-		});
+		}).catch(function() {});
 	}
 	return Promise.all([
 		process.env.HEROKU_AUTH_TOKEN ? Promise.resolve(process.env.HEROKU_AUTH_TOKEN) : commandLine.run('heroku', ['auth:token']),

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -67,7 +67,15 @@ module.exports = function(gulp, config) {
 		])
 		.then(function() {
 			if (config.browserTest) {
-				return module.exports.browserTest(gulp, config);
+				return module.exports.browserTest(gulp, config).then(function(){
+					resolve();
+				}).catch(function () {
+					if(config.browserTestFailBuild){
+						reject('Browser tests failed');
+					} else {
+						resolve();
+					}
+				});
 			} else {
 				resolve();
 			}
@@ -150,12 +158,16 @@ module.exports._runBrowserTest = function(config) {
 				if (error) {
 					reject(error);
 				}
-
-				resolve(commandLine.run(nightwatchCommand, [
+				const nightwatchCommandResult = commandLine.run(nightwatchCommand, [
 						'--group', testsPath,
 						'--config', tempNightwatchConfigPath,
 						'--env', environments
-				]));
+				]);
+				if(config.browserTestFailBuild){
+					nightwatchCommandResult.then(resolve, reject);
+				} else {
+					resolve(nightwatchCommandResult);
+				}
 			});
 		});
 	});
@@ -195,11 +207,9 @@ module.exports.browserTest = function(gulp, config) {
 		return haikro.destroy({
 			token: token,
 			app: appName
-
 			// Suppress any errors
-			}).catch(function() {});
+		});
 	}
-
 	return Promise.all([
 		process.env.HEROKU_AUTH_TOKEN ? Promise.resolve(process.env.HEROKU_AUTH_TOKEN) : commandLine.run('heroku', ['auth:token']),
 		commandLine.run('git', ['rev-parse', 'HEAD']),
@@ -242,7 +252,7 @@ module.exports.browserTest = function(gulp, config) {
 		cleanupTest(output);
 	})
 	.catch(function(e) {
-		cleanupTest()
+		return cleanupTest()
 			.then(function() {
 				if (typeof e.stdout !== 'undefined') {
 					log.secondary(e.stdout);

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -67,7 +67,7 @@ module.exports = function(gulp, config) {
 		])
 		.then(function() {
 			if (config.browserTest) {
-				return module.exports.browserTest(gulp, config).then(function(){
+				return module.exports.browserTest(gulp, config).then(function() {
 					resolve();
 				}).catch(function () {
 					if (config.browserTestFailBuild) {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -70,7 +70,7 @@ module.exports = function(gulp, config) {
 				return module.exports.browserTest(gulp, config).then(function(){
 					resolve();
 				}).catch(function () {
-					if(config.browserTestFailBuild){
+					if (config.browserTestFailBuild) {
 						reject('Browser tests failed');
 					} else {
 						resolve();
@@ -163,7 +163,7 @@ module.exports._runBrowserTest = function(config) {
 						'--config', tempNightwatchConfigPath,
 						'--env', environments
 				]);
-				if(config.browserTestFailBuild){
+				if (config.browserTestFailBuild) {
 					nightwatchCommandResult.then(resolve, reject);
 				} else {
 					resolve(nightwatchCommandResult);

--- a/test/tasks/build.test.js
+++ b/test/tasks/build.test.js
@@ -39,7 +39,7 @@ describe('Build task', function() {
 		afterEach(function() {
 			return fs.emptydirSync('build', function(){
 				fs.removeSync('build');
-			})
+			});
 		});
 
 		it('should work with default options', function(done) {

--- a/test/tasks/build.test.js
+++ b/test/tasks/build.test.js
@@ -37,7 +37,9 @@ describe('Build task', function() {
 		});
 
 		afterEach(function() {
-			return exec('rm -rf build');
+			return fs.emptydirSync('build', function(){
+				fs.removeSync('build');
+			})
 		});
 
 		it('should work with default options', function(done) {


### PR DESCRIPTION
Added a new flag `browserTestFailBuild` to allow failed browser tests to fail the build on CI.

The build of o-ads without new flag:
https://circleci.com/gh/Financial-Times/o-ads/45 - note that tests failed but build passed

The build of o-ads with new flag:
https://circleci.com/gh/Financial-Times/o-ads/46 - note tests failed and build failed

Both builds point to the the new branch

/cc @AlbertoElias @alicebartlett 