### PR TITLE
Define obt_env JS placeholder and $obt_env SCSS variable, and possibility to define custom vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Runs:
 	- sourcemaps: `Boolean | 'inline'` Set to true to output sourcemaps as a separate file, even if env is 'production'. Set to 'inline' to output sourcemaps inline (Default: false in production, true in development)
 	- loaders: `Array` Additional Webpack loaders for JavaScript files to run *before* imports-loader (removes AMD module support), babel-loader (which adds babel-runtime polyfills) and textrequireify-loader. OBT will search for loaders in its `node_modules` directory, but also in the project's `node_modules` folder. This way, you can install your own loaders and pass them to the `loaders` array by their name. e.g. `[coffee-loader]`
 	- standalone: `String` Export built file to a global variable with the name passed to this (Default: '')
+	- vars: `Object` These variables will be passed to the built resources as obt_var_{key}, with the corresponding value. Please note that the value will be a String.
 
 **In your JS files, you can use `obt_env`, which will be replaced with the value of `env` (either 'development' or 'production.'). Bear in mind that it's not a variable, it will be replaced with the string.**
 
@@ -116,6 +117,7 @@ Runs:
 	- env: `String` It can be either 'production' or 'development'. If it's 'production', it will compile the Sass file with the 'compressed' style option and will also run [clean-css](https://github.com/jakubpawlowicz/clean-css). (Default: 'development')
 	- cleanCss: `Object` Config object to pass to [clean-css](https://github.com/jakubpawlowicz/clean-css/blob/master/README.md#how-to-use-clean-css-programmatically). (Default: `{advanced: false}`)
 	- sassIncludePaths: `Array` List of paths to search for Sass imports. (Default: '[]')
+	- vars: `Object` These variables will be passed to the built resources as $obt_var_{key}, with the corresponding value.
 
 **In your SCSS files, you can use `$obt_env`, which is a variable with the value of `env` (either 'development' or 'production.').**
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Runs:
 	- sourcemaps: `Boolean | 'inline'` Set to true to output sourcemaps as a separate file, even if env is 'production'. Set to 'inline' to output sourcemaps inline (Default: false in production, true in development)
 	- loaders: `Array` Additional Webpack loaders for JavaScript files to run *before* imports-loader (removes AMD module support), babel-loader (which adds babel-runtime polyfills) and textrequireify-loader. OBT will search for loaders in its `node_modules` directory, but also in the project's `node_modules` folder. This way, you can install your own loaders and pass them to the `loaders` array by their name. e.g. `[coffee-loader]`
 	- standalone: `String` Export built file to a global variable with the name passed to this (Default: '')
+
+**In your JS files, you can use `obt_env`, which will be replaced with the value of `env` (either 'development' or 'production.'). Bear in mind that it's not a variable, it will be replaced with the string.**
+
 * __sass(gulp, config)__ Config accepts:
 	- sass: `String` Path to your main Sass file. (Default: './main.scss' and checks your bower.json to see if it's in its main key)
 	- autoprefixerBrowsers: `Array` An array of strings of [browser names for autoprefixer](https://github.com/postcss/autoprefixer#browsers) to check what prefixes it needs. (Default: `["> 1%", "last 2 versions", "ie > 6", "ff ESR"]`)
@@ -113,6 +116,8 @@ Runs:
 	- env: `String` It can be either 'production' or 'development'. If it's 'production', it will compile the Sass file with the 'compressed' style option and will also run [clean-css](https://github.com/jakubpawlowicz/clean-css). (Default: 'development')
 	- cleanCss: `Object` Config object to pass to [clean-css](https://github.com/jakubpawlowicz/clean-css/blob/master/README.md#how-to-use-clean-css-programmatically). (Default: `{advanced: false}`)
 	- sassIncludePaths: `Array` List of paths to search for Sass imports. (Default: '[]')
+
+**In your SCSS files, you can use `$obt_env`, which is a variable with the value of `env` (either 'development' or 'production.').**
 
 ### `demo`
 

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -64,6 +64,7 @@ module.exports.js = function(gulp, config) {
 		].concat(config.loaders || []);
 
 		config.env = config.env || 'development';
+		config.vars = config.vars || {};
 
 		const useSourceMaps = config.sourcemaps || (config.env === 'development');
 
@@ -92,6 +93,12 @@ module.exports.js = function(gulp, config) {
 		plugins.push(new webpack.webpack.DefinePlugin({
 			'obt_env': `"${config.env}"`
 		}));
+
+		Object.keys(config.vars).forEach((key) => {
+			const pluginConfig = {};
+			pluginConfig['obt_var_' + key] = `"${config.vars[key]}"`;
+			plugins.push(new webpack.webpack.DefinePlugin(pluginConfig));
+		});
 
 		const webpackConfig = {
 			quiet: true,
@@ -178,7 +185,15 @@ module.exports.sass = function(gulp, config) {
 
 		const combinedStream = combine.obj(
 			gulp.src(src),
-			inject.prepend('$obt_env: \'' + config.env + '\';'),
+			inject.prepend(`$obt_env: '${config.env}';`),
+			gulpif(config.vars, function () {
+				const varInjects = [];
+				Object.keys(config.vars).forEach((key) => {
+					varInjects.push(inject.prepend(`$obt_var_${key}: '${config.vars[key]}';`));
+				});
+
+				return combine.obj.apply(this, varInjects);
+			}),
 			gulpif(config.sassPrefix, function() {
 				return prefixer(config.sassPrefix);
 			}),

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -14,6 +14,7 @@ const autoprefixer = require('gulp-autoprefixer');
 const prefixer = require('../plugins/gulp-prefixer');
 const files = require('../helpers/files');
 const log = require('../helpers/log');
+const inject = require('gulp-inject-string');
 
 module.exports = function(gulp, config) {
 	let jsStream;
@@ -87,6 +88,11 @@ module.exports.js = function(gulp, config) {
 				sourceMap: useSourceMaps
 			}));
 		}
+
+		plugins.push(new webpack.webpack.DefinePlugin({
+			'obt_env': `"${config.env}"`
+		}));
+
 		const webpackConfig = {
 			quiet: true,
 			resolve: {
@@ -172,6 +178,7 @@ module.exports.sass = function(gulp, config) {
 
 		const combinedStream = combine.obj(
 			gulp.src(src),
+			inject.prepend('$obt_env: \'' + config.env + '\';'),
 			gulpif(config.sassPrefix, function() {
 				return prefixer(config.sassPrefix);
 			}),

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "through2": "^2.0.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "webpack-stream": "github:albertoelias/webpack-stream",
+    "webpack-stream": "AlbertoElias/webpack-stream",
     "which": "^1.1.1"
   },
   "devDependencies": {
@@ -65,58 +65,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Financial-Times/origami-build-tools.git"
+    "url": "https://github.com/Financial-Times/origami-build-tools.git"
   },
-  "license": "MIT",
-  "gitHead": "3979740edcafe471e5d1a19f3e12d2d42516a4fa",
-  "bugs": {
-    "url": "https://github.com/Financial-Times/origami-build-tools/issues"
-  },
-  "homepage": "https://github.com/Financial-Times/origami-build-tools#readme",
-  "_id": "origami-build-tools@5.1.1",
-  "_shasum": "aaa96ccb16122da612fdc59d55a1960ac33cd1b3",
-  "_from": "origami-build-tools@>=5.0.1 <6.0.0",
-  "_npmVersion": "2.14.14",
-  "_nodeVersion": "5.6.0",
-  "_npmUser": {
-    "name": "albertoelias",
-    "email": "me@alberto-elias.com"
-  },
-  "dist": {
-    "shasum": "aaa96ccb16122da612fdc59d55a1960ac33cd1b3",
-    "tarball": "https://registry.npmjs.org/origami-build-tools/-/origami-build-tools-5.1.1.tgz"
-  },
-  "maintainers": [
-    {
-      "name": "albertoelias",
-      "email": "me@alberto-elias.com"
-    },
-    {
-      "name": "ftlabs",
-      "email": "ftlabs-opensource@ft.com"
-    },
-    {
-      "name": "kaelig",
-      "email": "kaelig@deloumeau.fr"
-    },
-    {
-      "name": "kornel",
-      "email": "pornel@pornel.net"
-    },
-    {
-      "name": "mattandrews",
-      "email": "matt@mattandre.ws"
-    },
-    {
-      "name": "samgiles",
-      "email": "sam@samgil.es"
-    }
-  ],
-  "_npmOperationalInternal": {
-    "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/origami-build-tools-5.1.1.tgz_1461243103339_0.49191167345270514"
-  },
-  "directories": {},
-  "_resolved": "https://registry.npmjs.org/origami-build-tools/-/origami-build-tools-5.1.1.tgz",
-  "readme": "ERROR: No README data found!"
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "through2": "^2.0.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "webpack-stream": "AlbertoElias/webpack-stream",
+    "webpack-stream": "github:albertoelias/webpack-stream",
     "which": "^1.1.1"
   },
   "devDependencies": {
@@ -65,7 +65,58 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Financial-Times/origami-build-tools.git"
+    "url": "git+https://github.com/Financial-Times/origami-build-tools.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "gitHead": "3979740edcafe471e5d1a19f3e12d2d42516a4fa",
+  "bugs": {
+    "url": "https://github.com/Financial-Times/origami-build-tools/issues"
+  },
+  "homepage": "https://github.com/Financial-Times/origami-build-tools#readme",
+  "_id": "origami-build-tools@5.1.1",
+  "_shasum": "aaa96ccb16122da612fdc59d55a1960ac33cd1b3",
+  "_from": "origami-build-tools@>=5.0.1 <6.0.0",
+  "_npmVersion": "2.14.14",
+  "_nodeVersion": "5.6.0",
+  "_npmUser": {
+    "name": "albertoelias",
+    "email": "me@alberto-elias.com"
+  },
+  "dist": {
+    "shasum": "aaa96ccb16122da612fdc59d55a1960ac33cd1b3",
+    "tarball": "https://registry.npmjs.org/origami-build-tools/-/origami-build-tools-5.1.1.tgz"
+  },
+  "maintainers": [
+    {
+      "name": "albertoelias",
+      "email": "me@alberto-elias.com"
+    },
+    {
+      "name": "ftlabs",
+      "email": "ftlabs-opensource@ft.com"
+    },
+    {
+      "name": "kaelig",
+      "email": "kaelig@deloumeau.fr"
+    },
+    {
+      "name": "kornel",
+      "email": "pornel@pornel.net"
+    },
+    {
+      "name": "mattandrews",
+      "email": "matt@mattandre.ws"
+    },
+    {
+      "name": "samgiles",
+      "email": "sam@samgil.es"
+    }
+  ],
+  "_npmOperationalInternal": {
+    "host": "packages-12-west.internal.npmjs.com",
+    "tmp": "tmp/origami-build-tools-5.1.1.tgz_1461243103339_0.49191167345270514"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/origami-build-tools/-/origami-build-tools-5.1.1.tgz",
+  "readme": "ERROR: No README data found!"
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-autoprefixer": "^3.1.0",
     "gulp-eslint": "^1.0.0",
     "gulp-if-else": "^1.0.3",
+    "gulp-inject-string": "^1.1.0",
     "gulp-lintspaces": "^0.3.0",
     "gulp-minify-css": "^1.1.6",
     "gulp-mustache": "^2.2.0",


### PR DESCRIPTION
Define obt_env JS placeholder and $obt_env SCSS variable with the vaue of env in order to be able to make decisions based on the build type.

Also, by adding vars object, obt_env_{varKey} and $obt_env_{varKey} will be passed to the JS and SCSS resources.