### PR TITLE
get webpack to use NODE_ENV='production' in building if in production

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -86,6 +86,7 @@ module.exports.js = function(gulp, config) {
 			plugins.push(new webpack.webpack.optimize.UglifyJsPlugin({
 				sourceMap: useSourceMaps
 			}));
+			plugins.push(new webpack.webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }));
 		}
 		const webpackConfig = {
 			quiet: true,


### PR DESCRIPTION
That’s to get the webpack to use NODE_ENV=‘production’ in build - most notably this is a requirement for React to use their super-minified version.