### PR TITLE
add a raw loader for HTML requires

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -115,6 +115,10 @@ module.exports.js = function(gulp, config) {
 					{
 						test: /\.json$/,
 						loader: 'json'
+					},
+					{
+						test: /\.html$/,
+						loader: 'raw'
 					}
 				]
 			},

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "node.extend": "^1.1.5",
     "npmconf": "^2.1.2",
     "portfinder": "^0.4.0",
+    "raw-loader": "^0.5.1",
     "semver": "^5.1.0",
     "stream-combiner2": "1.0.2",
     "through2": "^2.0.0",


### PR DESCRIPTION
This allows the following:

`const template = require('templates/foobar.html')`

where template will become `<h1>Hello world</h1>` if the contents of `templates/foobar.html` is `<h1>Hello world</h1>`.

If people wish to continue and use `requireText`, they can do so. This doesn't break `requireText`. This simply tells `webpack` what to do if it sees a `require('....html')`.