### PR TITLE
Uses !important in ctm css

### DIFF
--- a/templates/page.mustache
+++ b/templates/page.mustache
@@ -6,7 +6,7 @@
 	<title>{{oDemoTitle}}</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features={{oDemoBrowserFeatures}}"></script>
-	<style>body { margin: 0; } .core .o--if-js, .enhanced .o--if-no-js { display: none; }</style>
+	<style>body { margin: 0; } .core .o--if-js, .enhanced .o--if-no-js { display: none !important; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	{{{oDemoStyle}}}
 </head>


### PR DESCRIPTION
Makes it use the same example as the spec: http://origami.ft.com/docs/developer-guide/modules/core-vs-enhanced-experience/#add-styles-to-hide-core-only-html-in-origami