### PR TITLE
:zap: improvement: Updates .eslintrc to work in eslint^2

### DIFF
--- a/config/.eslintrc
+++ b/config/.eslintrc
@@ -2,6 +2,9 @@
 	"ecmaFeatures": {
 		"modules": true
 	},
+	"parserOptions": {
+		"sourceType": "module"
+	},
 	"env": {
 		"es6": true,
 		"browser": true


### PR DESCRIPTION
As per the [eslint migration guide](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-2.0.0.md#language-options), `parserOptions.sourceType` must be set to `module` in order to avoid error: 

> Parsing error: 'import' and 'export' may appear only with 'sourceType: module'