### PR TITLE
Deprecate the expanded property for demos

### DIFF
--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -213,6 +213,7 @@ module.exports.origamiJson = function() {
 		if (fs.existsSync(origamiJsonPath)) {
 			log.secondary('Verifying your origami.json');
 			const origamiJson = JSON.parse(fs.readFileSync(origamiJsonPath, 'utf8'));
+			const componentDemos = origamiJson.demos;
 			if (!origamiJson.description) {
 				result.push('A non-empty description property is required');
 			}
@@ -227,6 +228,15 @@ module.exports.origamiJson = function() {
 			}
 			if (['active', 'maintained', 'deprecated', 'dead', 'experimental'].indexOf(origamiJson.supportStatus) === -1) {
 				result.push('The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"');
+			}
+
+			for (let i = 0; i < componentDemos.length; i++) {
+				let demo = componentDemos[i];
+
+				if (demo.hasOwnProperty('expanded')) {
+					result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
+					break;
+				}
 			}
 
 			if (result.length > 0) {

--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -230,12 +230,14 @@ module.exports.origamiJson = function() {
 				result.push('The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"');
 			}
 
-			for (let i = 0; i < componentDemos.length; i++) {
-				let demo = componentDemos[i];
+			if (componentDemos) {
+				for (let i = 0; i < componentDemos.length; i++) {
+					let demo = componentDemos[i];
 
-				if (demo.hasOwnProperty('expanded')) {
-					result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
-					break;
+					if (demo.hasOwnProperty('expanded')) {
+						result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
+						break;
+					}
 				}
 			}
 

--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -231,13 +231,12 @@ module.exports.origamiJson = function() {
 			}
 
 			if (componentDemos) {
-				for (let i = 0; i < componentDemos.length; i++) {
-					let demo = componentDemos[i];
+				const hasExpanded = componentDemos.some(function(demo) {
+					return demo.hasOwnProperty('expanded');
+				});
 
-					if (demo.hasOwnProperty('expanded')) {
-						result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
-						break;
-					}
+				if (hasExpanded) {
+					result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
 				}
 			}
 

--- a/test/fixtures/o-test/origami.json
+++ b/test/fixtures/o-test/origami.json
@@ -14,14 +14,12 @@
             "name": "test1",
             "template": "demos/src/test1.mustache",
             "path": "/demos/test1.html",
-            "expanded": true,
             "description": "First test"
         },
         {
             "name": "test2",
             "template": "demos/src/test2.mustache",
             "path": "/demos/test2.html",
-            "expanded": false,
             "description": "Second test"
         }
     ],

--- a/test/tasks/verify.test.js
+++ b/test/tasks/verify.test.js
@@ -68,21 +68,39 @@ describe('Verify task', function() {
 		});
 	});
 
-	it('should run origamiJson check', function(done) {
-		verify.origamiJson()
-			.then(function(verifiedOrigamiJson) {
-				expect(verifiedOrigamiJson.length).to.be(0);
-				fs.writeFileSync('origami.json', JSON.stringify({}), 'utf8');
-				return verify.origamiJson();
-			})
-			.then(function() {}, function(verifiedOrigamiJson) {
-				expect(verifiedOrigamiJson).to.contain('A non-empty description property is required');
-				expect(verifiedOrigamiJson).to.contain('The origamiType property needs to be set to either "module" or "service"');
-				expect(verifiedOrigamiJson).to.contain('A non-empty description property is required');
-				expect(verifiedOrigamiJson).to.contain('The origamiVersion property needs to be set to 1');
-				expect(verifiedOrigamiJson).to.contain('The support property must be an email or url to an issue tracker for this module');
-				expect(verifiedOrigamiJson).to.contain('The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"');
-				done();
-			});
+	describe('verify origami.json', function() {
+		it('should run origami.json check successfully', function(done) {
+			verify.origamiJson()
+				.then(function(verifiedOrigamiJson) {
+					expect(verifiedOrigamiJson.length).to.be(0);
+					done();
+				});
+		});
+
+		it('should fail with an empty origami.json', function(done) {
+			fs.writeFileSync('origami.json', JSON.stringify({}), 'utf8');
+
+			verify.origamiJson()
+				.then(function() {}, function(verifiedOrigamiJson) {
+					expect(verifiedOrigamiJson).to.contain('A non-empty description property is required');
+					expect(verifiedOrigamiJson).to.contain('The origamiType property needs to be set to either "module" or "service"');
+					expect(verifiedOrigamiJson).to.contain('A non-empty description property is required');
+					expect(verifiedOrigamiJson).to.contain('The origamiVersion property needs to be set to 1');
+					expect(verifiedOrigamiJson).to.contain('The support property must be an email or url to an issue tracker for this module');
+					expect(verifiedOrigamiJson).to.contain('The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"');
+					done();
+				});
+		});
+
+		it('should fail when an expanded property is found for a demo', function(done) {
+			fs.writeFileSync('origami.json', JSON.stringify({ demos: [ { expanded: false }, { expanded: true } ] }), 'utf8');
+
+			verify.origamiJson()
+				.then(function() {}, function(verifiedOrigamiJson) {
+					expect(verifiedOrigamiJson).to.contain('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
+					done();
+				});
+		});
 	});
+
 });


### PR DESCRIPTION
Add a failing test for the verify task which looks for the expanded property in component demos.

Do not merge until the new Registry has been deployed.