### PR TITLE
Add feature: Analytics

### DIFF
--- a/lib/helpers/metrics.js
+++ b/lib/helpers/metrics.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const Graphite = require('graphite');
+
+const graphiteHost = 'graphite.ft.com';
+const graphitePort = 2003;
+
+const graphite = Graphite.createClient('plaintext://' + graphiteHost + ':' + graphitePort);
+
+module.exports = function(data) {
+	const metrics = {
+		origami: {
+			buildtools: data
+		}
+	};
+
+	graphite.write(metrics, function(){});
+};

--- a/lib/origami-build-tools.js
+++ b/lib/origami-build-tools.js
@@ -2,6 +2,16 @@
 
 require('isomorphic-fetch');
 
+const metrics = require('./helpers/metrics');
+const nodeVersion = process.version.slice(1).split('.')[0];
+const data = {
+	nodeVersion : {
+		invoked: {}
+	}
+};
+data.nodeVersion.invoked[nodeVersion] = 1;
+metrics(data);
+
 const update = require('./helpers/update-notifier');
 const log = require('./helpers/log');
 update();

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "denodeify": "^1.2.1",
     "falafel": "^1.2.0",
     "findit": "^2.0.0",
+    "graphite": "0.0.6",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-clean-css": "^2.0.12",
@@ -63,6 +64,8 @@
     "expect.js": "^0.3.1",
     "fs-extra": "^0.30.0",
     "mocha": "^3.0.2",
+    "mockery": "^1.7.0",
+    "sinon": "^1.17.5",
     "vinyl": "^1.2.0"
   },
   "repository": {

--- a/test/origami-build-tools.test.js
+++ b/test/origami-build-tools.test.js
@@ -32,13 +32,13 @@ describe('obt', function() {
 
 	beforeEach(function() {
 		mockery.resetCache();
-	});
-
-	after(() => {
 		fetchMock.reset();
 		logMock.reset();
 		updateNotifierMock.reset();
 		metricsMock.reset();
+	});
+
+	after(() => {
 		mockery.resetCache();
 		mockery.deregisterAll();
 		mockery.disable();

--- a/test/origami-build-tools.test.js
+++ b/test/origami-build-tools.test.js
@@ -1,41 +1,40 @@
 /* eslint-env mocha, expect */
 'use strict';
+
 const expect = require('expect.js');
 const mockery = require('mockery');
 const sinon = require('sinon');
 
 describe('obt', function() {
 
-	const fetchMock = sinon.stub();
-	mockery.registerMock('isomorphic-fetch', fetchMock);
-
-	const updateNotifierMock = sinon.stub();
-	mockery.registerMock('./helpers/update-notifier', updateNotifierMock);
-
-	const logMock = sinon.stub();
-	mockery.registerMock('./helpers/log', logMock);
-
-	const metricsMock = sinon.stub();
-	mockery.registerMock('./helpers/metrics', metricsMock);
-
 	const moduleUnderTest = '../lib/origami-build-tools';
 
-	mockery.enable({
-		useCleanCache: true,
-		warnOnReplace: false,
-		warnOnUnregistered: false
-	});
-
-	mockery.registerAllowable(moduleUnderTest);
-
 	const version = process.version;
+	const fetchMock = sinon.stub();
+	const updateNotifierMock = sinon.stub();
+	const logMock = sinon.stub();
+	const metricsMock = sinon.stub();
 
 	beforeEach(function() {
-		mockery.resetCache();
 		fetchMock.reset();
 		logMock.reset();
 		updateNotifierMock.reset();
 		metricsMock.reset();
+
+		mockery.enable({
+			useCleanCache: true,
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		});
+
+		mockery.registerMock('isomorphic-fetch', fetchMock);
+		mockery.registerMock('./helpers/update-notifier', updateNotifierMock);
+		mockery.registerMock('./helpers/log', logMock);
+		mockery.registerMock('./helpers/metrics', metricsMock);
+
+		mockery.registerAllowable(moduleUnderTest);
+
+		mockery.resetCache();
 	});
 
 	after(() => {

--- a/test/origami-build-tools.test.js
+++ b/test/origami-build-tools.test.js
@@ -1,0 +1,77 @@
+/* eslint-env mocha, expect */
+'use strict';
+const expect = require('expect.js');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('obt', function() {
+
+	const fetchMock = sinon.stub();
+	mockery.registerMock('isomorphic-fetch', fetchMock);
+
+	const updateNotifierMock = sinon.stub();
+	mockery.registerMock('./helpers/update-notifier', updateNotifierMock);
+
+	const logMock = sinon.stub();
+	mockery.registerMock('./helpers/log', logMock);
+
+	const metricsMock = sinon.stub();
+	mockery.registerMock('./helpers/metrics', metricsMock);
+
+	const moduleUnderTest = '../lib/origami-build-tools';
+
+	mockery.enable({
+		useCleanCache: true,
+		warnOnReplace: false,
+		warnOnUnregistered: false
+	});
+
+	mockery.registerAllowable(moduleUnderTest);
+
+	const version = process.version;
+
+	beforeEach(function() {
+		mockery.resetCache();
+	});
+
+	after(() => {
+		fetchMock.reset();
+		logMock.reset();
+		updateNotifierMock.reset();
+		metricsMock.reset();
+		mockery.resetCache();
+		mockery.deregisterAll();
+		mockery.disable();
+		process.version = version;
+	});
+
+	it('passes the node major version to the metrics module', function() {
+		delete process.version;
+		process.version = 'v6.0.1';
+		require(moduleUnderTest);
+		expect(metricsMock.calledOnce).to.equal(true);
+		expect(metricsMock.args[0].length).to.equal(1);
+		expect(metricsMock.args[0][0]).to.eql({
+			nodeVersion: {
+				invoked: {
+					6: 1
+				}
+			}
+		});
+	});
+
+	it('passes the node major version to the metrics module', function() {
+		delete process.version;
+		process.version = 'v4.0.1';
+		require(moduleUnderTest);
+		expect(metricsMock.calledOnce).to.equal(true);
+		expect(metricsMock.args[0].length).to.equal(1);
+		expect(metricsMock.args[0][0]).to.eql({
+			nodeVersion: {
+				invoked: {
+					4: 1
+				}
+			}
+		});
+	});
+});


### PR DESCRIPTION
This makes a start to addressing #390.

This adds Graphite reporting capabilities and uses them to track the major version of node being used when executing OBT whether from the command line or programatically.