### PR TITLE
Add phantomjs-prebuilt for pa11y to work without extra set-up steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "node.extend": "^1.1.5",
     "npmconf": "^2.1.2",
     "pa11y": "^4.0.0",
+    "phantomjs-prebuilt": "^2.1.12",
     "portfinder": "^1.0.7",
     "raw-loader": "^0.5.1",
     "semver": "^5.1.0",


### PR DESCRIPTION
Adding this means people no longer have to install PhantomJS separately to run Pa11y tests.
This can be removed if the PR to Pa11y is merge -- https://github.com/pa11y/pa11y/pull/190