### PR TITLE
Backporting - Pipe command output to stderr/stdout whilst keeping same interface - v5

### DIFF
--- a/lib/helpers/command-line.js
+++ b/lib/helpers/command-line.js
@@ -1,56 +1,14 @@
 'use strict';
 
-const childProcess = require('child_process');
-const which = require('which');
-const log = require('./log');
-const windows = (process.platform.indexOf('win32') >= 0 || process.platform.indexOf('win64') >= 0);
+const execa = require('execa');
 
-function run(command, args, options) {
-	return new Promise(function(resolve, reject) {
-		let stdOut = '';
-		let stdErr = '';
+function run(command, args) {
+	const result = execa(command, args);
 
-		if (windows) {
-			args.unshift('/c', command);
-			command = 'cmd';
-		}
+	result.stdout.pipe(process.stdout);
+	result.stderr.pipe(process.stderr);
 
-		try {
-			command = which.sync(command);
-		} catch (e) {
-			reject({ stdout: stdOut, stderr: stdErr, err: e });
-		}
-
-		const fullCommand = command + ' ' + args.join(' ');
-
-		const pro = childProcess.exec(fullCommand, options);
-
-		pro.on('error', function(error) {
-			log.secondaryError(error);
-		});
-
-		pro.on('close', function(code) {
-			const output = { 'stderr': stdErr, 'stdout': stdOut };
-
-			if (code !== 0) {
-				output.err = code;
-				reject(output);
-			}
-			resolve(output);
-		});
-
-		if (pro.stderr) {
-			pro.stderr.on('data', function(data) {
-				stdErr += data;
-			});
-		}
-
-		if (pro.stdout) {
-			pro.stdout.on('data', function(data) {
-				stdOut += data;
-			});
-		}
-	});
+	return result;
 }
 
 exports.run = run;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "colors": "^1.1.2",
     "configstore": "^2.1.0",
     "denodeify": "^1.2.1",
+    "execa": "^0.6.3",
     "falafel": "^1.2.0",
     "findit": "^2.0.0",
     "graphite": "0.0.6",

--- a/test/helpers/command-line.test.js
+++ b/test/helpers/command-line.test.js
@@ -8,15 +8,15 @@ const commandLine = require('../../lib/helpers/command-line');
 describe('Command line helper', function() {
 	it('should return output from stdout', function(done) {
 		commandLine.run('echo', ['test']).then(function(output) {
-			expect(output.stdout).to.be('test\n');
+			expect(output.stdout).to.be('test');
 			done();
 		});
 	});
 
 	it('should return output from stderr', function(done) {
 		commandLine.run('node', ['error']).then(function() {}, function(output) {
-			expect(output.stderr).to.contain('throw err;\n');
-			expect(output.err).to.be(1);
+			expect(output.stderr).to.contain('throw err;');
+			expect(output.code).to.be(1);
 			done();
 		});
 	});


### PR DESCRIPTION
Same as #418 but for OBT version 5 instead of OBT version 6.

You can view the diff against v5.5.5 here --> https://github.com/Financial-Times/origami-build-tools/compare/v5.5.5...magic-v5