### PR TITLE
🐛 Fixes invalid scss-lint config option

### DIFF
--- a/config/scss-lint.yml
+++ b/config/scss-lint.yml
@@ -17,7 +17,7 @@ options:
 rules:
   border-zero:
     - 2
-    - convention: zero
+    - convention: 0
   brace-style:
     - 2
     - allow-single-line: true


### PR DESCRIPTION
The scss-lint config passes an invalid option and so this message appears:
> The border-zero convention `zero` in your config file is not valid. Defaulted to convention `0`

This changes `zero` to simply `0` as per [the docs](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#borderzero).