### PR TITLE
Remove the version hack

### DIFF
--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -98,12 +98,6 @@ function runWatcher(task, gulp, config) {
 	});
 }
 
-// Mini-hack to make Origami Build Tools support the pseudo standard CLI language of --version
-if (cli.version) {
-	delete cli.version;
-	cli._[0] = '--version';
-}
-
 const watch = !!cli.flags.watch;
 const argument = cli.input[0];
 


### PR DESCRIPTION
No longer needed now that we use `meow`.