### PR TITLE
Add Safari 8+ to autoprefixer config

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -198,7 +198,7 @@ module.exports.sass = function (gulp, config) {
 		};
 
 		const autoprefixerConfig = {
-			browsers: config.autoprefixerBrowsers || ['> 1%', 'last 2 versions', 'ie > 6', 'ff ESR', 'bb >= 7'],
+			browsers: config.autoprefixerBrowsers || ['> 1%', 'last 2 versions', 'ie > 6', 'ff ESR', 'bb >= 7', 'safari >= 8'],
 			cascade: config.autoprefixerCascade || false,
 			flexbox: 'no-2009',
 			remove: config.autoprefixerRemove === undefined ? true : config.autoprefixerRemove


### PR DESCRIPTION
Safari version 8 requires the prefixed version of flexbox to work successfully.

Fixes https://github.com/Financial-Times/o-teaser/issues/49