### PR TITLE
Move verify origami task to new file and add lots of tests

### DIFF
--- a/lib/tasks/verify-origami-json.js
+++ b/lib/tasks/verify-origami-json.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function origamiJson () {
+	return new Promise(function(resolve, reject) {
+		const result = [];
+
+		const origamiJsonPath = path.join(process.cwd(), '/origami.json');
+		if (fs.existsSync(origamiJsonPath)) {
+			const origamiJson = JSON.parse(fs.readFileSync(origamiJsonPath, 'utf8'));
+			const componentDemos = origamiJson.demos;
+			if (!origamiJson.description) {
+				result.push('A non-empty description property is required');
+			}
+			if (origamiJson.origamiType !== 'module' && origamiJson.origamiType !== 'service') {
+				result.push('The origamiType property needs to be set to either "module" or "service"');
+			}
+			if (origamiJson.origamiVersion !== 1) {
+				result.push('The origamiVersion property needs to be set to 1');
+			}
+			if (!origamiJson.support) {
+				result.push('The support property must be an email or url to an issue tracker for this module');
+			}
+			if (['active', 'maintained', 'deprecated', 'dead', 'experimental'].indexOf(origamiJson.supportStatus) === -1) {
+				result.push('The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"');
+			}
+
+			if (componentDemos) {
+				const hasExpanded = componentDemos.some(function(demo) {
+					return demo.hasOwnProperty('expanded');
+				});
+
+				if (hasExpanded) {
+					result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
+				}
+			}
+
+			if (result.length > 0) {
+				reject(new Error('Failed linting:\n\n' + result.join('\n') + '\n\nThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'));
+			} else {
+				resolve(result);
+			}
+		}
+	});
+};
+
+module.exports = {
+	title: 'Verifying your origami.json',
+	task: origamiJson,
+	skip: () => {
+		const origamiJsonPath = path.join(process.cwd(), '/origami.json');
+		if (!fs.existsSync(origamiJsonPath)) {
+			return `No origami.json file found. To make this an origami component, create a file at ${path.join(process.cwd(), '/origami.json')} following the format defined at: http://origami.ft.com/docs/syntax/origamijson/`;
+		}
+	}
+};

--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -8,8 +8,8 @@ const sasslint = require('gulp-sass-lint');
 const lintspaces = require('gulp-lintspaces');
 const through = require('through2');
 const combine = require('stream-combiner2');
-const merge = require('merge-stream');
 const gutil = require('gulp-util');
+const verifyOrigamiJsonFile = require('./verify-origami-json');
 
 const cwd = process.cwd();
 const excludePath = path.join(cwd, '/.gitignore');
@@ -21,54 +21,28 @@ if (fs.existsSync(excludePath)) {
 	log.secondary('No .gitignore found so command will run on all files in your project');
 }
 
-module.exports = function(gulp, config) {
-	const verifyStream = merge();
-	const emitVerifyStreamErrorEvent = verifyStream.emit.bind(verifyStream, 'error');
+module.exports = function (gulp, config) {
+	const Listr = require('listr');
 
-	module.exports.origamiJson();
-	const esLintStream = module.exports.esLint(gulp, config)
-		.on('error', emitVerifyStreamErrorEvent);
-	const sassLintStream = module.exports.sassLint(gulp, config)
-		.on('error', emitVerifyStreamErrorEvent);
-	const lintspacesStream = module.exports.lintspaces(gulp, config)
-		.on('error', emitVerifyStreamErrorEvent);
-
-	verifyStream.add(esLintStream, sassLintStream, lintspacesStream);
-	return verifyStream;
+	return new Listr(
+		[
+			verifyOrigamiJsonFile,
+			{
+				title: 'Linting Javascript',
+				task: () => module.exports.esLint(gulp, config)
+			}
+		]
+	)
+	.run();
 };
 
 function pathsToGlob(paths) {
-	const globPatterns = [];
 
 	function filterEmptyAndComments(line) {
 		return line && line[0] !== '#';
 	}
 
-	function createGlobPatterns(line) {
-		let prefix = '';
-		// if the line starts with a ! it's an inclusion so we remove the ! otherwise we add ! to make it an exclusion
-		if (line[0] === '!') {
-			line = line.slice(1);
-		} else {
-			prefix = '!';
-		}
-
-		if (line[line.length - 1] === '/') {
-			// if it's a directory add ** to exclude everything within
-			line = line + '**';
-		} else {
-			// if it's not explicitly a directory add a directory exclusion just in case
-			globPatterns.push(prefix + path.join(cwd, line + '/**'));
-
-		}
-
-		// add the original line
-		globPatterns.push(prefix + path.join(cwd, line));
-		return line;
-	}
-
-	paths.filter(filterEmptyAndComments).forEach(createGlobPatterns);
-	return globPatterns;
+	return paths.filter(filterEmptyAndComments);
 }
 
 //
@@ -184,53 +158,6 @@ module.exports.lintspaces = function(gulp, config) {
 	// and it will have effects in all the steps. We need to resume() because stream-combiner2
 	// seems to pause the stream and it doesn't reach the `end` event
 	return combinedStream.resume();
-};
-
-module.exports.origamiJson = function() {
-	return new Promise(function(resolve, reject) {
-		const result = [];
-
-		const origamiJsonPath = path.join(process.cwd(), '/origami.json');
-		if (fs.existsSync(origamiJsonPath)) {
-			log.secondary('Verifying your origami.json');
-			const origamiJson = JSON.parse(fs.readFileSync(origamiJsonPath, 'utf8'));
-			const componentDemos = origamiJson.demos;
-			if (!origamiJson.description) {
-				result.push('A non-empty description property is required');
-			}
-			if (origamiJson.origamiType !== 'module' && origamiJson.origamiType !== 'service') {
-				result.push('The origamiType property needs to be set to either "module" or "service"');
-			}
-			if (origamiJson.origamiVersion !== 1) {
-				result.push('The origamiVersion property needs to be set to 1');
-			}
-			if (!origamiJson.support) {
-				result.push('The support property must be an email or url to an issue tracker for this module');
-			}
-			if (['active', 'maintained', 'deprecated', 'dead', 'experimental'].indexOf(origamiJson.supportStatus) === -1) {
-				result.push('The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"');
-			}
-
-			if (componentDemos) {
-				const hasExpanded = componentDemos.some(function(demo) {
-					return demo.hasOwnProperty('expanded');
-				});
-
-				if (hasExpanded) {
-					result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
-				}
-			}
-
-			if (result.length > 0) {
-				for (let i = 0; i < result.length; i++) {
-					log.secondaryError(result[i]);
-				}
-				reject(result);
-			} else {
-				resolve(result);
-			}
-		}
-	});
 };
 
 module.exports.watchable = false;

--- a/test/tasks/verify-origami-json.test.js
+++ b/test/tasks/verify-origami-json.test.js
@@ -1,0 +1,355 @@
+/* eslint-env mocha */
+'use strict';
+
+const proclaim = require('proclaim');
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const verifyOrigamiJson = require('../../lib/tasks/verify-origami-json');
+
+const obtPath = process.cwd();
+const oTestPath = 'test/fixtures/o-test';
+const pathSuffix = '-verify';
+const verifyTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
+
+describe('verify-origami-json', function () {
+	beforeEach(function () {
+		fs.copySync(path.resolve(obtPath, oTestPath), verifyTestPath);
+		process.chdir(verifyTestPath);
+		fs.writeFileSync('src/scss/verify.scss', '$color: #ccc;\n\np {\n  color: $color!important ;\n}\n', 'utf8');
+		fs.writeFileSync('src/js/verify.js', 'const test = \'We live in financial times\';\n');
+	});
+
+	afterEach(function () {
+		process.chdir(obtPath);
+		fs.removeSync(path.resolve(obtPath, verifyTestPath));
+	});
+
+	describe('default title', () => {
+		it('should be "Executing Pa11y"', () => {
+			proclaim.equal(verifyOrigamiJson.title, 'Verifying your origami.json');
+		});
+	});
+
+	describe('skip', () => {
+		it('should return true if the file does not exist', () => {
+			fs.removeSync(path.join(process.cwd(), '/origami.json'));
+			proclaim.ok(verifyOrigamiJson.skip());
+		});
+
+		it('should return a helpful message if the file does not exist', () => {
+			fs.removeSync(path.join(process.cwd(), '/origami.json'));
+			proclaim.equal(verifyOrigamiJson.skip(), `No origami.json file found. To make this an origami component, create a file at ${path.join(process.cwd(), '/origami.json')} following the format defined at: http://origami.ft.com/docs/syntax/origamijson/`);
+		});
+
+		it('should return a falsey value if the file does exist', () => {
+			proclaim.notOk(verifyOrigamiJson.skip());
+		});
+	});
+
+	describe('task', function () {
+		it('should run origami.json check successfully', function () {
+			return verifyOrigamiJson.task()
+				.then(function (verifiedOrigamiJson) {
+					proclaim.equal(verifiedOrigamiJson.length, 0);
+				});
+		});
+
+		it('should fail with an empty origami.json', function () {
+			fs.writeFileSync('origami.json', JSON.stringify({}), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.match(verifiedOrigamiJson, /A non-empty description property is required/);
+					proclaim.match(verifiedOrigamiJson, /The origamiType property needs to be set to either "module" or "service"/);
+					proclaim.match(verifiedOrigamiJson, /The origamiVersion property needs to be set to 1/);
+					proclaim.match(verifiedOrigamiJson, /The support property must be an email or url to an issue tracker for this module/);
+					proclaim.match(verifiedOrigamiJson, /The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"/);
+				});
+		});
+
+		it('should fail if missing description property', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			delete origamiJSON.description;
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'A non-empty description property is required\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail if description property is an empty string', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.description = '';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'A non-empty description property is required\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail if description property is a string containing only spaces', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.description = '      ';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'A non-empty description property is required\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail if missing origamiType property', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			delete origamiJSON.origamiType;
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The origamiType property needs to be set to either "module" or "service"\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail if origamiType property is not "module" or "service"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.origamiType = '';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The origamiType property needs to be set to either "module" or "service"\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should pass if origamiType property is "module"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.origamiType = 'module';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should pass if origamiType property is "service"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.origamiType = 'service';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should fail if missing origamiVersion property', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			delete origamiJSON.origamiVersion;
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The origamiVersion property needs to be set to 1\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail if origamiVersion property is not 1', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.origamiVersion = 2;
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The origamiVersion property needs to be set to 1\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should pass if origamiVersion property is 1', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.origamiVersion = 1;
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should fail if missing support property', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			delete origamiJSON.support;
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The support property must be an email or url to an issue tracker for this module\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail if support property is not an email address or url', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.support = '   ';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The support property must be an email or url to an issue tracker for this module\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should pass if support property is an email address', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.support = 'support@example.com';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should pass if support property is a url', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.support = 'https://example.com';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should fail if missing supportStatus property', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			delete origamiJSON.supportStatus;
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail if supportStatus property is not "active", "maintained", "deprecated", "dead" or "experimental"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.supportStatus = '  ';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should pass if supportStatus property is "active"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.supportStatus = 'active';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should pass if supportStatus property is "maintained"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.supportStatus = 'maintained';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should pass if supportStatus property is "deprecated"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.supportStatus = 'deprecated';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should pass if supportStatus property is "dead"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.supportStatus = 'dead';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should pass if supportStatus property is "experimental"', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.supportStatus = 'experimental';
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task();
+		});
+
+		it('should fail when an expanded property is found for a demo', function () {
+			const origamiJSON = require(path.join(process.cwd(), 'origami.json'));
+			origamiJSON.demos = [{
+				expanded: false
+			}, {
+				expanded: true
+			}];
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson.task()
+				.then(function () {}, function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+	});
+
+});

--- a/test/tasks/verify.test.js
+++ b/test/tasks/verify.test.js
@@ -68,36 +68,4 @@ describe('Verify task', function() {
 		});
 	});
 
-	describe('verify origami.json', function() {
-		it('should run origami.json check successfully', function() {
-			return verify.origamiJson()
-				.then(function(verifiedOrigamiJson) {
-					expect(verifiedOrigamiJson.length).to.be(0);
-				});
-		});
-
-		it('should fail with an empty origami.json', function() {
-			fs.writeFileSync('origami.json', JSON.stringify({}), 'utf8');
-
-			return verify.origamiJson()
-				.then(function() {}, function(verifiedOrigamiJson) {
-					expect(verifiedOrigamiJson).to.contain('A non-empty description property is required');
-					expect(verifiedOrigamiJson).to.contain('The origamiType property needs to be set to either "module" or "service"');
-					expect(verifiedOrigamiJson).to.contain('A non-empty description property is required');
-					expect(verifiedOrigamiJson).to.contain('The origamiVersion property needs to be set to 1');
-					expect(verifiedOrigamiJson).to.contain('The support property must be an email or url to an issue tracker for this module');
-					expect(verifiedOrigamiJson).to.contain('The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"');
-				});
-		});
-
-		it('should fail when an expanded property is found for a demo', function() {
-			fs.writeFileSync('origami.json', JSON.stringify({ demos: [ { expanded: false }, { expanded: true } ] }), 'utf8');
-
-			return verify.origamiJson()
-				.then(function() {}, function(verifiedOrigamiJson) {
-					expect(verifiedOrigamiJson).to.contain('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
-				});
-		});
-	});
-
 });


### PR DESCRIPTION
This starts the work off for moving the `obt verify` task to using the Listr module. I have also separated out the Origami verification tasks to a separate file to make it simpler to understand what dependencies it is using, this is what has also been done for the `obt test` task in the past.