### PR TITLE
Remove old way of specifying demos using javascript.

### DIFF
--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -259,7 +259,6 @@ module.exports = function(gulp, config) {
 	// can keep on compiling demos of older versions of modules
 	let configPaths = [
 		'demos/src/config.json',
-		'demos/src/config.js',
 		'origami.json'
 	];
 	let configPath;
@@ -281,7 +280,16 @@ module.exports = function(gulp, config) {
 	if (configPath) {
 		log.primary('Building' + (config.dist ? ' build service' : ' local') + ' demos (config: ' + configPath + ')');
 
-		const demosConfig = require(configPath);
+		let demosConfig;
+
+		try {
+			demosConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		} catch (error) {
+			const demoConfigError = `${configPath} is not valid JSON.`;
+			const demoConfigErrorStream = errorStream(demoStream, demoConfigError);
+			return demoConfigErrorStream;
+		}
+
 		const demos = [];
 		builtFiles.css = [];
 		builtFiles.js = [];

--- a/test/tasks/demo.test.js
+++ b/test/tasks/demo.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, after */
+/* eslint-env mocha */
 'use strict';
 
 const expect = require('expect.js');
@@ -43,7 +43,7 @@ describe('Demo task', function() {
 			fs.writeFileSync('bower.json', '{"name":"o-test"}', 'utf8');
 			demo(gulp)
 				.on('error', function(err) {
-					expect(err.message).to.be('Couldn\'t find demos config path, checked: origami.json,demos/src/config.js,demos/src/config.json');
+					expect(err.message).to.be('Couldn\'t find demos config path, checked: origami.json,demos/src/config.json');
 					fs.unlink(path.resolve(obtPath, 'bower.json'));
 					process.chdir(demoTestPath);
 					done();


### PR DESCRIPTION
Origami used to allow a JS file to be used to configure Origami demos. We are removing this as it can be abused to run arbitrary code within the origami-build-tools process.