### PR TITLE
use raw-loader for .txt files

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -123,6 +123,10 @@ module.exports.js = function (gulp, config) {
 					{
 						test: /\.html$/,
 						loader: 'raw'
+					},
+					{
+						test: /\.txt$/,
+						loader: 'raw'
 					}
 				]
 			},


### PR DESCRIPTION
n-webpack uses handlebars to compile .html files and obt uses the raw-loader to return the html as a string. This caused issues on o-comments as handlebars returns a function instead of a string.

To avoid this confusion, we have both agreed to use .txt to signify require calls which should return strings of the file being required.

This PR and a PR to change o-comment-ui to use .txt instaed of .html will mean that next-article can be updated to the new origami components! 🎉 