### PR TITLE
Allow remote demo data

### DIFF
--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -90,6 +90,7 @@ function buildJs(buildConfig) {
 }
 
 function loadRemoteDemoData(url) {
+	const genericErrorMessage = 'Could not load remote demo data.';
 	return request.get({
 		uri: url,
 		json: true
@@ -98,7 +99,15 @@ function loadRemoteDemoData(url) {
 		if (typeof data === 'object') {
 			return data;
 		}
-		const e = new Error(`${url} did not provide valid JSON.`);
+		throw new Error(`${genericErrorMessage} ${url} did not provide valid JSON.`);
+	}).catch((err) => {
+		if (err.name === 'RequestError') {
+			err.message = `${genericErrorMessage} ${url} does not appear to be valid.`;
+		}
+		if (err.name === 'StatusCodeError') {
+			  err.message = `${genericErrorMessage} ${url} returned a ${err.statusCode} status code.`;
+		}
+		const e = new Error(err.message);
 		e.stack = '';
 		throw e;
 	});

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -125,7 +125,7 @@ function loadLocalDemoData(dataPath) {
 function loadDemoData(buildConfig) {
 	if (typeof buildConfig.demo.data === 'string') {
 		const dataPathIsAbsolute = /^(?:https?:)\/\//.test(buildConfig.demo.data);
-		const dataPath = (dataPathIsAbsolute ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data));
+		const dataPath = dataPathIsAbsolute ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data);
 		if (dataPathIsAbsolute) {
 			return loadExternalDemoData(dataPath);
 		} else {

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -99,17 +99,19 @@ function loadRemoteDemoData(url) {
 		if (typeof data === 'object') {
 			return data;
 		}
-		throw new Error(`${genericErrorMessage} ${url} did not provide valid JSON.`);
+		const err = new Error(`${genericErrorMessage} ${url} did not provide valid JSON.`);
+		err.stack = '';
+		throw err;
 	}).catch((err) => {
 		if (err.name === 'RequestError') {
 			err.message = `${genericErrorMessage} ${url} does not appear to be valid.`;
+			err.stack = '';
 		}
 		if (err.name === 'StatusCodeError') {
 			  err.message = `${genericErrorMessage} ${url} returned a ${err.statusCode} status code.`;
+			  err.stack = '';
 		}
-		const e = new Error(err.message);
-		e.stack = '';
-		throw e;
+		throw err;
 	});
 }
 

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -95,7 +95,12 @@ function loadExternalDemoData(url) {
 		json: true
 	})
 	.then(data => {
-		return data;
+		if (typeof data === 'object') {
+			return data;
+		}
+		const e = new Error(`${url} did not provide valid JSON.`);
+		e.stack = '';
+		throw e;
 	});
 }
 
@@ -124,9 +129,9 @@ function loadLocalDemoData(dataPath) {
 
 function loadDemoData(buildConfig) {
 	if (typeof buildConfig.demo.data === 'string') {
-		const dataPathIsAbsolute = /^(?:https?:)\/\//.test(buildConfig.demo.data);
-		const dataPath = dataPathIsAbsolute ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data);
-		if (dataPathIsAbsolute) {
+		const dataPathIsRemote = /^(?:https?:)\/\//.test(buildConfig.demo.data);
+		const dataPath = dataPathIsRemote ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data);
+		if (dataPathIsRemote) {
 			return loadExternalDemoData(dataPath);
 		} else {
 			return loadLocalDemoData(dataPath);

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -9,6 +9,7 @@ const buildsass = require('../tasks/build-sass');
 const mustache = require('mustache');
 const denodeify = require('denodeify');
 const nodeSass = require('node-sass');
+const request = require('request-promise-native');
 
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
@@ -90,27 +91,38 @@ function buildJs(buildConfig) {
 
 function loadDemoData(buildConfig) {
 	if (typeof buildConfig.demo.data === 'string') {
-		const dataPath = path.join(buildConfig.cwd, '/' + buildConfig.demo.data);
-		return fileExists(dataPath)
-			.then(exists => {
-				if (exists) {
-					return readFile(dataPath, 'utf-8')
-						.then(file => {
-							try {
-								const fileData = JSON.parse(file);
-								if (typeof fileData === 'object') {
-									return fileData;
-								} else {
-									return {};
-								}
-							} catch (error) {
-								const e = new Error(`${dataPath} is not valid JSON.`);
-								e.stack = '';
-								throw e;
-							}
-						});
-				}
+		const dataPathIsAbsolute = /^(?:https?:)\/\//.test(buildConfig.demo.data);
+		const dataPath = (dataPathIsAbsolute ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data));
+		if (dataPathIsAbsolute) {
+			return request({
+				uri: dataPath,
+				json: true
+			})
+			.then(data => {
+				return data;
 			});
+		} else {
+			return fileExists(dataPath)
+				.then(exists => {
+					if (exists) {
+						return readFile(dataPath, 'utf-8')
+							.then(file => {
+								try {
+									const fileData = JSON.parse(file);
+									if (typeof fileData === 'object') {
+										return fileData;
+									} else {
+										return {};
+									}
+								} catch (error) {
+									const e = new Error(`${dataPath} is not valid JSON.`);
+									e.stack = '';
+									throw e;
+								}
+							});
+					}
+				});
+		}
 	} else if (typeof buildConfig.demo.data === 'object') {
 		return Promise.resolve(buildConfig.demo.data);
 	} else {

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -116,25 +116,25 @@ function loadRemoteDemoData(url) {
 }
 
 function loadLocalDemoData(dataPath) {
-	return fileExists(dataPath)
-		.then(exists => {
-			if (exists) {
-				return readFile(dataPath, 'utf-8')
-					.then(file => {
-						try {
-							const fileData = JSON.parse(file);
-							if (typeof fileData === 'object') {
-								return fileData;
-							} else {
-								return {};
-							}
-						} catch (error) {
-							const e = new Error(`${dataPath} is not valid JSON.`);
-							e.stack = '';
-							throw e;
-						}
-					});
+	return readFile(dataPath, 'utf-8')
+		.then(file => {
+			try {
+				const fileData = JSON.parse(file);
+				if (typeof fileData === 'object') {
+					return fileData;
+				} else {
+					return {};
+				}
+			} catch (error) {
+				const e = new Error(`${dataPath} is not valid JSON.`);
+				e.stack = '';
+				throw e;
 			}
+		})
+		.catch(() => {
+			const e = new Error(`Demo data not found: ${dataPath}`);
+			e.stack = '';
+			throw e;
 		});
 }
 

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -89,7 +89,7 @@ function buildJs(buildConfig) {
 	}
 }
 
-function loadExternalDemoData(url) {
+function loadRemoteDemoData(url) {
 	return request.get({
 		uri: url,
 		json: true
@@ -132,7 +132,7 @@ function loadDemoData(buildConfig) {
 		const dataPathIsRemote = /^(?:https?:)\/\//.test(buildConfig.demo.data);
 		const dataPath = dataPathIsRemote ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data);
 		if (dataPathIsRemote) {
-			return loadExternalDemoData(dataPath);
+			return loadRemoteDemoData(dataPath);
 		} else {
 			return loadLocalDemoData(dataPath);
 		}

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -89,39 +89,47 @@ function buildJs(buildConfig) {
 	}
 }
 
+function loadExternalDemoData(url) {
+	return request({
+		uri: url,
+		json: true
+	})
+	.then(data => {
+		return data;
+	});
+}
+
+function loadLocalDemoData(dataPath) {
+	return fileExists(dataPath)
+		.then(exists => {
+			if (exists) {
+				return readFile(dataPath, 'utf-8')
+					.then(file => {
+						try {
+							const fileData = JSON.parse(file);
+							if (typeof fileData === 'object') {
+								return fileData;
+							} else {
+								return {};
+							}
+						} catch (error) {
+							const e = new Error(`${dataPath} is not valid JSON.`);
+							e.stack = '';
+							throw e;
+						}
+					});
+			}
+		});
+}
+
 function loadDemoData(buildConfig) {
 	if (typeof buildConfig.demo.data === 'string') {
 		const dataPathIsAbsolute = /^(?:https?:)\/\//.test(buildConfig.demo.data);
 		const dataPath = (dataPathIsAbsolute ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data));
 		if (dataPathIsAbsolute) {
-			return request({
-				uri: dataPath,
-				json: true
-			})
-			.then(data => {
-				return data;
-			});
+			return loadExternalDemoData(dataPath);
 		} else {
-			return fileExists(dataPath)
-				.then(exists => {
-					if (exists) {
-						return readFile(dataPath, 'utf-8')
-							.then(file => {
-								try {
-									const fileData = JSON.parse(file);
-									if (typeof fileData === 'object') {
-										return fileData;
-									} else {
-										return {};
-									}
-								} catch (error) {
-									const e = new Error(`${dataPath} is not valid JSON.`);
-									e.stack = '';
-									throw e;
-								}
-							});
-					}
-				});
+			return loadLocalDemoData(dataPath);
 		}
 	} else if (typeof buildConfig.demo.data === 'object') {
 		return Promise.resolve(buildConfig.demo.data);

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -90,7 +90,7 @@ function buildJs(buildConfig) {
 }
 
 function loadExternalDemoData(url) {
-	return request({
+	return request.get({
 		uri: url,
 		json: true
 	})

--- a/package-lock.json
+++ b/package-lock.json
@@ -4666,6 +4666,24 @@
         "acorn": "5.1.1"
       }
     },
+    "is-es6-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-es6-syntax/-/is-es6-syntax-1.0.1.tgz",
+      "integrity": "sha512-V4pq0OxmOXioZ5jq2sp54sHpW6I7RQrRxmCRS65vTdV3NI1YT+9n1IUF4p3Dy8bZXWGIdJEShXL5DZdiiKDj0g==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1"
+      }
+    },
+    "is-es7-syntax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-es7-syntax/-/is-es7-syntax-1.0.0.tgz",
+      "integrity": "sha512-hulqMm5jb1NTG09HhxpfQ0jNaClGI2i7nZ6hamkFGhPGUw7KhaprN99LxqUf/lwsLwTO0L3SMuRl1U9CwhVOGA==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1"
+      }
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4203,6 +4203,13 @@
       "requires": {
         "lazy-socket": "0.0.3",
         "request": "2.1.1"
+      },
+      "dependencies": {
+        "request": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.1.1.tgz",
+          "integrity": "sha1-VXDgxzfWVuvW0dPICqUQ08+Gxvo="
+        }
       }
     },
     "growl": {
@@ -6037,7 +6044,7 @@
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
         "osenv": "0.1.4",
-        "request": "2.1.1",
+        "request": "2.81.0",
         "rimraf": "2.6.1",
         "semver": "5.3.0",
         "tar": "2.2.1",
@@ -7570,9 +7577,57 @@
       }
     },
     "request": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.1.1.tgz",
-      "integrity": "sha1-VXDgxzfWVuvW0dPICqUQ08+Gxvo="
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.16",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "request-progress": {
       "version": "2.0.1",
@@ -7580,6 +7635,24 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "requires": {
         "throttleit": "1.0.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.4.tgz",
+      "integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.2"
       }
     },
     "require-directory": {
@@ -8342,6 +8415,11 @@
       "requires": {
         "readable-stream": "2.3.3"
       }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha -t 50000 `find . -name '*.test.js' -path './test/*'`"
+    "test": "mocha -t 50000 ./test/tasks/demo-build.test.js"
   },
   "dependencies": {
     "aliases": "^0.1.0",
@@ -67,6 +67,8 @@
     "portfinder": "^1.0.7",
     "postcss": "^5.2.17",
     "raw-loader": "^0.5.1",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.4",
     "root-check": "^1.0.0",
     "sass-lint": "^1.10.2",
     "serve": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha -t 50000 `find . -name '*.test.js' -path './test/*'`"
+    "test": "mocha -t 50000 `find . -name '*.test.js' -path './test/*'`",
+    "mocha": "mocha"
   },
   "dependencies": {
     "aliases": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha -t 50000 `find . -name '*.test.js' -path './test/*'`",
-    "mocha": "mocha"
+    "test": "mocha -t 50000 `find . -name '*.test.js' -path './test/*'`"
   },
   "dependencies": {
     "aliases": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha -t 50000 ./test/tasks/demo-build.test.js"
+    "test": "mocha -t 50000 `find . -name '*.test.js' -path './test/*'`"
   },
   "dependencies": {
     "aliases": "^0.1.0",

--- a/test/tasks/demo-build.test.js
+++ b/test/tasks/demo-build.test.js
@@ -96,21 +96,33 @@ describe('Demo task', function () {
 				"hidden": true,
 				"description": "Second test"
 			});
+			demoConfig.demos.push({
+				"name": "test3",
+				"template": "demos/src/test3.mustache",
+				"path": "/demos/test3.html",
+				"description": "Third test",
+				"data": "https://www.ft.com/__origami/service/navigation/v2/menus/footer/?source=test"
+			});
 			fs.writeFileSync('origami.json', JSON.stringify(demoConfig));
 			fs.writeFileSync('demos/src/test1.mustache', '<div>test1</div>', 'utf8');
 			fs.writeFileSync('demos/src/test2.mustache', '<div>test2</div>', 'utf8');
+			fs.writeFileSync('demos/src/test3.mustache', '<div>{{{label}}}</div>', 'utf8');
 			return demo({
 				production: true
 			})
 				.then(function () {
 					const test1 = fs.readFileSync('demos/test1.html', 'utf8');
 					const test2 = fs.readFileSync('demos/test2.html', 'utf8');
+					const test3 = fs.readFileSync('demos/test3.html', 'utf8');
 					expect(test1).to.contain('<div>test1</div>');
 					expect(test2).to.contain('<div>test2</div>');
+					expect(test3).to.contain('<div>Footer</div>');
 					expect(test1).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
 					expect(test2).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
+					expect(test3).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
 					fs.unlinkSync('demos/test1.html');
 					fs.unlinkSync('demos/test2.html');
+					fs.unlinkSync('demos/test3.html');
 				});
 		});
 

--- a/test/tasks/demo-build.test.js
+++ b/test/tasks/demo-build.test.js
@@ -129,10 +129,6 @@ describe('Demo task', function () {
 				expect(test1).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
 				expect(test2).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
 				expect(testRemoteData).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
-				fs.unlinkSync('demos/test1.html');
-				fs.unlinkSync('demos/test2.html');
-				fs.unlinkSync('demos/remote-data.html');
-				request.get.restore();
 			});
 		});
 
@@ -271,8 +267,6 @@ describe('Demo task', function () {
 					const test2 = fs.readFileSync('demos/test2.html', 'utf8');
 					expect(test1).to.contain('<div>partial1</div>');
 					expect(test2).to.contain('<div>partial2</div>');
-					fs.unlinkSync('demos/test1.html');
-					fs.unlinkSync('demos/test2.html');
 				});
 		});
 	});

--- a/test/tasks/demo-build.test.js
+++ b/test/tasks/demo-build.test.js
@@ -176,6 +176,7 @@ describe('Demo task', function () {
 				throw new Error('promise resolved when it should have rejected');
 			}).catch(function (err) {
 				expect(err.message).to.be(`Could not load remote demo data. ${remoteDataUrl} did not provide valid JSON.`);
+				expect(err.stack).to.be('');
 			});
 		});
 
@@ -196,6 +197,7 @@ describe('Demo task', function () {
 				throw new Error('promise resolved when it should have rejected');
 			}).catch(function (err) {
 				expect(err.message).to.be(`Could not load remote demo data. ${remoteDataUrl} does not appear to be valid.`);
+				expect(err.stack).to.be('');
 			});
 		});
 
@@ -223,6 +225,34 @@ describe('Demo task', function () {
 				throw new Error('promise resolved when it should have rejected');
 			}).catch(function (err) {
 				expect(err.message).to.be(`Could not load remote demo data. ${remoteDataUrl} returned a ${mockHttpError.statusCode} status code.`);
+				expect(err.stack).to.be('');
+			});
+		});
+
+
+		it('should show a stack trace if remote demo data retrieval fails for an unknown reason', function () {
+			// Stub for request/request-promise-native StatusCodeError.
+			const request = require('request-promise-native');
+			const mockHttpError = new Error('Mock Unknown Error');
+			mockHttpError.name = 'UnknownError';
+			sandbox.stub(request, 'get').callsFake(() => Promise.reject(mockHttpError));
+			// Create demo config.
+			const remoteDataUrl = 'http://origami.ft.com/#stubedRequest';
+			addDemoToOrigamiConfig({
+				"name": "remote-data",
+				"template": "demos/src/remote-data.mustache",
+				"path": "/demos/remote-data.html",
+				"description": "Remote data url unknown error.",
+				"data": remoteDataUrl
+			});
+			// Run error HTTP status code test. Tests the request/request-promise-native
+			// error is caught and transformed, but not that the library throws the error.
+			return demo({
+				production: true
+			}).then(function () {
+				throw new Error('promise resolved when it should have rejected');
+			}).catch(function (err) {
+				expect(err.stack).not.to.be('');
 			});
 		});
 

--- a/test/tasks/demo-build.test.js
+++ b/test/tasks/demo-build.test.js
@@ -85,7 +85,10 @@ describe('Demo task', function () {
 		it('should build demo html', function () {
 			const request = require('request-promise-native');
 			const demoDataLabel = 'Footer';
-			sinon.stub(request, 'get').callsFake(() => Promise.resolve({"label": demoDataLabel, "items": []}));
+			sinon.stub(request, 'get').callsFake(() => Promise.resolve({
+				"label": demoDataLabel,
+				"items": []
+			}));
 
 			const demoConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
 			demoConfig.demos.push({
@@ -114,21 +117,20 @@ describe('Demo task', function () {
 			fs.writeFileSync('demos/src/remote-data.mustache', '<div>{{{label}}}</div>', 'utf8');
 			return demo({
 				production: true
-			})
-				.then(function () {
-					const test1 = fs.readFileSync('demos/test1.html', 'utf8');
-					const test2 = fs.readFileSync('demos/test2.html', 'utf8');
-					const remoteData = fs.readFileSync('demos/remote-data.html', 'utf8');
-					expect(test1).to.contain('<div>test1</div>');
-					expect(test2).to.contain('<div>test2</div>');
-					expect(remoteData).to.contain(`<div>Footer</div>`);
-					expect(test1).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
-					expect(test2).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
-					expect(remoteData).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
-					fs.unlinkSync('demos/test1.html');
-					fs.unlinkSync('demos/test2.html');
-					fs.unlinkSync('demos/remote-data.html');
-				});
+			}).then(function () {
+				const test1 = fs.readFileSync('demos/test1.html', 'utf8');
+				const test2 = fs.readFileSync('demos/test2.html', 'utf8');
+				const testRemoteData = fs.readFileSync('demos/remote-data.html', 'utf8');
+				expect(test1).to.contain('<div>test1</div>');
+				expect(test2).to.contain('<div>test2</div>');
+				expect(testRemoteData).to.contain(`<div>Footer</div>`);
+				expect(test1).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
+				expect(test2).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
+				expect(testRemoteData).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
+				fs.unlinkSync('demos/test1.html');
+				fs.unlinkSync('demos/test2.html');
+				fs.unlinkSync('demos/remote-data.html');
+			});
 		});
 
 		it('should build local demos', function () {

--- a/test/tasks/demo-build.test.js
+++ b/test/tasks/demo-build.test.js
@@ -91,29 +91,24 @@ describe('Demo task', function () {
 				"label": demoDataLabel,
 				"items": []
 			}));
-
-			const demoConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
-			demoConfig.demos.push({
+			addDemoToOrigamiConfig([{
 				"name": "test1",
 				"template": "demos/src/test1.mustache",
 				"path": "/demos/test1.html",
 				"description": "First test"
-			});
-			demoConfig.demos.push({
+			}, {
 				"name": "test2",
 				"template": "demos/src/test2.mustache",
 				"path": "/demos/test2.html",
 				"hidden": true,
 				"description": "Second test"
-			});
-			demoConfig.demos.push({
+			}, {
 				"name": "remote-data",
 				"template": "demos/src/remote-data.mustache",
 				"path": "/demos/remote-data.html",
 				"description": "Third test",
 				"data": "http://origami.ft.com/#stubedRequest"
-			});
-			fs.writeFileSync('origami.json', JSON.stringify(demoConfig));
+			}]);
 			fs.writeFileSync('demos/src/test1.mustache', '<div>test1</div>', 'utf8');
 			fs.writeFileSync('demos/src/test2.mustache', '<div>test2</div>', 'utf8');
 			fs.writeFileSync('demos/src/remote-data.mustache', '<div>{{{label}}}</div>', 'utf8');
@@ -121,33 +116,30 @@ describe('Demo task', function () {
 				production: true
 			}).then(function () {
 				const test1 = fs.readFileSync('demos/test1.html', 'utf8');
-				const test2 = fs.readFileSync('demos/test2.html', 'utf8');
-				const testRemoteData = fs.readFileSync('demos/remote-data.html', 'utf8');
 				expect(test1).to.contain('<div>test1</div>');
-				expect(test2).to.contain('<div>test2</div>');
-				expect(testRemoteData).to.contain(`<div>${demoDataLabel}</div>`);
 				expect(test1).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
+				const test2 = fs.readFileSync('demos/test2.html', 'utf8');
+				expect(test2).to.contain('<div>test2</div>');
 				expect(test2).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
+				const testRemoteData = fs.readFileSync('demos/remote-data.html', 'utf8');
+				expect(testRemoteData).to.contain(`<div>${demoDataLabel}</div>`);
 				expect(testRemoteData).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
 			});
 		});
 
 		it('should build local demos', function () {
-			const demoConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
-			demoConfig.demos.push({
+			addDemoToOrigamiConfig([{
 				"name": "test1",
 				"template": "demos/src/test1.mustache",
 				"path": "/demos/test1.html",
 				"description": "First test"
-			});
-			demoConfig.demos.push({
+			}, {
 				"name": "test2",
 				"template": "demos/src/test2.mustache",
 				"path": "/demos/test2.html",
 				"hidden": true,
 				"description": "Second test"
-			});
-			fs.writeFileSync('origami.json', JSON.stringify(demoConfig));
+			}]);
 			fs.writeFileSync('demos/src/test1.mustache', '<div>test1</div>', 'utf8');
 			fs.writeFileSync('demos/src/test2.mustache', '<div>test2</div>', 'utf8');
 			return demo()
@@ -168,17 +160,15 @@ describe('Demo task', function () {
 				"items": []}}}
 			}`));
 			// Create demo config.
-			const demoConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
 			const remoteDataUrl = 'http://origami.ft.com/#stubedRequest';
 			fs.writeFileSync('demos/src/remote-data.mustache', '<div>{{{label}}}</div>', 'utf8');
-			demoConfig.demos.push({
+			addDemoToOrigamiConfig({
 				"name": "remote-data",
 				"template": "demos/src/remote-data.mustache",
 				"path": "/demos/remote-data.html",
 				"description": "Invalid remote data test",
 				"data": remoteDataUrl
 			});
-			fs.writeFileSync('origami.json', JSON.stringify(demoConfig));
 			// Run invalid json test.
 			return demo({
 				production: true
@@ -190,18 +180,15 @@ describe('Demo task', function () {
 		});
 
 		it('should fail if a remote url is invalid', function () {
-			// Create demo config.
-			const demoConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
+			// Create invalid demo data config.
 			const remoteDataUrl = 'https://!@£$%^&*()';
-			fs.writeFileSync('demos/src/remote-data.mustache', '<div>{{{label}}}</div>', 'utf8');
-			demoConfig.demos.push({
+			addDemoToOrigamiConfig({
 				"name": "remote-data",
 				"template": "demos/src/remote-data.mustache",
 				"path": "/demos/remote-data.html",
 				"description": "Invalid url",
 				"data": remoteDataUrl
 			});
-			fs.writeFileSync('origami.json', JSON.stringify(demoConfig));
 			// Run remote url test.
 			return demo({
 				production: true
@@ -220,18 +207,16 @@ describe('Demo task', function () {
 			mockHttpError.statusCode = '500';
 			sandbox.stub(request, 'get').callsFake(() => Promise.reject(mockHttpError));
 			// Create demo config.
-			const demoConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
 			const remoteDataUrl = 'http://origami.ft.com/#stubedRequest';
-			fs.writeFileSync('demos/src/remote-data.mustache', '<div>{{{label}}}</div>', 'utf8');
-			demoConfig.demos.push({
+			addDemoToOrigamiConfig({
 				"name": "remote-data",
 				"template": "demos/src/remote-data.mustache",
 				"path": "/demos/remote-data.html",
 				"description": "Remote data url http error.",
 				"data": remoteDataUrl
 			});
-			fs.writeFileSync('origami.json', JSON.stringify(demoConfig));
-			// Error HTTP status code.
+			// Run error HTTP status code test. Tests the request/request-promise-native
+			// error is caught and transformed, but not that the library throws the error.
 			return demo({
 				production: true
 			}).then(function () {
@@ -242,21 +227,20 @@ describe('Demo task', function () {
 		});
 
 		it('should load local partials', function () {
-			const demoConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
-			demoConfig.demos.push({
-				"name": "test1",
-				"template": "demos/src/test1.mustache",
-				"path": "/demos/test1.html",
-				"description": "First test"
-			});
-			demoConfig.demos.push({
-				"name": "test2",
-				"template": "demos/src/test2.mustache",
-				"path": "/demos/test2.html",
-				"hidden": true,
-				"description": "Second test"
-			});
-			fs.writeFileSync('origami.json', JSON.stringify(demoConfig));
+			addDemoToOrigamiConfig([
+				{
+					"name": "test1",
+					"template": "demos/src/test1.mustache",
+					"path": "/demos/test1.html",
+					"description": "First test"
+				}, {
+					"name": "test2",
+					"template": "demos/src/test2.mustache",
+					"path": "/demos/test2.html",
+					"hidden": true,
+					"description": "Second test"
+				}
+			]);
 			fs.writeFileSync('demos/src/test1.mustache', '<div>test1</div>{{>partial1}}', 'utf8');
 			fs.writeFileSync('demos/src/test2.mustache', '<div>test1</div>{{>partials/partial2}}', 'utf8');
 			return demo({
@@ -269,5 +253,14 @@ describe('Demo task', function () {
 					expect(test2).to.contain('<div>partial2</div>');
 				});
 		});
+
+		function addDemoToOrigamiConfig (demosConfig) {
+			if (!Array.isArray(demosConfig)) {
+				demosConfig = [demosConfig];
+			}
+			const origamiConfig = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
+			demosConfig.forEach((demoConfig) => origamiConfig.demos.push(demoConfig));
+			fs.writeFileSync('origami.json', JSON.stringify(origamiConfig));
+		}
 	});
 });

--- a/test/tasks/demo-build.test.js
+++ b/test/tasks/demo-build.test.js
@@ -123,7 +123,7 @@ describe('Demo task', function () {
 				const testRemoteData = fs.readFileSync('demos/remote-data.html', 'utf8');
 				expect(test1).to.contain('<div>test1</div>');
 				expect(test2).to.contain('<div>test2</div>');
-				expect(testRemoteData).to.contain(`<div>Footer</div>`);
+				expect(testRemoteData).to.contain(`<div>${demoDataLabel}</div>`);
 				expect(test1).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
 				expect(test2).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);
 				expect(testRemoteData).to.match(/\/v2\/polyfill\.min\.js\?features=.*promises/);


### PR DESCRIPTION
In some cases we would like to use external data when building component demos so our demos match reality. For example in `o-footer`:
https://github.com/Financial-Times/o-footer/issues/81

For reliability of build this should be used sparingly. The `o-footer` example would depend on the navigation service, a "platinum" application.


E.g `origami.json` `demos` config using a remote data source (new ability):
```
{
    "name": "footer",
    "title": "Dark theme",
    "template": "demos/src/footer-dark.mustache",
    "data": "https://www.ft.com/__origami/service/navigation/v2/menus/footer/?source=test",
    "description": "This is the standard masterbrand footer used on most pages."
}
```

E.g `origami.json` `demos` config using a local data source (current):
```
{
    "name": "footer",
    "title": "Dark theme",
    "template": "demos/src/footer-dark.mustache",
    "data": "demos/src/footer.json",
    "description": "This is the standard masterbrand footer used on most pages."
}
```
