### PR TITLE
Don't attempt to compile demos if no demos exist

### DIFF
--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -36,7 +36,7 @@ module.exports = function (cfg) {
 				})
 				.catch(() => {
 					return `No origami.json file found at ${configPath}`;
-				})
+				});
 		}
 	}], {
 		renderer: require('../helpers/listr-renderer')

--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const Listr = require('listr');
+const path = require('path');
+const fs = require('fs');
+const denodeify = require('denodeify');
+const readFile = denodeify(fs.readFile);
 const buildDemo = require('./demo-build');
 
 module.exports = function (cfg) {
@@ -12,6 +16,27 @@ module.exports = function (cfg) {
 		title: 'Compiling Demos',
 		task: () => {
 			return buildDemo(config);
+		},
+		skip: () => {
+			const configPath = path.join(config.cwd, 'origami.json');
+			return readFile(configPath)
+				.then(file => {
+					let demosConfig;
+					try {
+						demosConfig = JSON.parse(file);
+					} catch (error) {
+						return `${configPath} is not valid JSON.`;
+					}
+
+					if (!Array.isArray(demosConfig.demos) || demosConfig.demos.length < 1) {
+						return 'No demos exist in origami.json file. Reference http://origami.ft.com/docs/syntax/origamijson/ to help configure demos for the component.';
+					}
+
+					return false;
+				})
+				.catch(() => {
+					return `No origami.json file found at ${configPath}`;
+				})
 		}
 	}], {
 		renderer: require('../helpers/listr-renderer')


### PR DESCRIPTION
We have a few components which have no demos such as o-autoinit. This will stop `obt demo` from attempting to compile any demos for such components.