### PR TITLE
Allow test files to have any name ending in .js

### DIFF
--- a/config/karma.config.js
+++ b/config/karma.config.js
@@ -37,7 +37,8 @@ module.exports = {
 
 	// list of files / patterns to load in the browser
 	files: [
-		'test/*.test.js'
+		'test/*.js',
+		'test/**/*.js'
 	],
 
 	// frameworks to use
@@ -59,7 +60,8 @@ module.exports = {
 	// preprocess matching files before serving them to the browser
 	// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 	preprocessors: {
-		'test/*.test.js': ['webpack', 'sourcemap']
+		'test/*.js': ['webpack', 'sourcemap'],
+		'test/**/*.js': ['webpack', 'sourcemap']
 	},
 
 	// Continuous Integration mode

--- a/lib/tasks/karma.js
+++ b/lib/tasks/karma.js
@@ -89,7 +89,7 @@ module.exports = (cfg) => {
 				cwd: config.cwd
 			};
 
-			return deglob(['test/**/*.test.js', 'test/*.test.js'], opts)
+			return deglob(['test/**/*.js', 'test/*.js'], opts)
 				.then(function (files) {
 					if (files.length === 0) {
 						return 'No test files found, consider adding some tests to make sure the code is working as expected.';


### PR DESCRIPTION
Some components such as o-ads-embed have their test files end in `.spec.js`, as the suffix for test files is not specified in the origami specification, we should allow any suffix to exist.