### PR TITLE
Use a verbose renderer for CLI output when running in a CI environment

### DIFF
--- a/lib/helpers/listr-renderer.js
+++ b/lib/helpers/listr-renderer.js
@@ -1,4 +1,6 @@
 'use strict';
+
+const isCI = require('is-ci');
 const chalk = require('chalk');
 const logSymbols = require('log-symbols');
 const figures = require('figures');
@@ -80,6 +82,10 @@ class UpdateRenderer {
 		}, options);
 	}
 
+	static get nonTTY() {
+		return false;
+	}
+
 	render() {
 		if (this._id) {
 			// Do not render if we are already rendering
@@ -107,4 +113,4 @@ class UpdateRenderer {
 	}
 }
 
-module.exports = UpdateRenderer;
+module.exports = isCI ? 'verbose' : UpdateRenderer;

--- a/lib/helpers/listr-renderer.js
+++ b/lib/helpers/listr-renderer.js
@@ -82,10 +82,6 @@ class UpdateRenderer {
 		}, options);
 	}
 
-	static get nonTTY() {
-		return false;
-	}
-
 	render() {
 		if (this._id) {
 			// Do not render if we are already rendering

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "origami-build-tools",
-  "version": "7.0.0-beta.12",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1532,6 +1532,11 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "ci-info": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -4676,6 +4681,14 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "1.1.1"
+      }
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "requires": {
+        "ci-info": "1.1.1"
       }
     },
     "is-docker": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "graphite": "0.0.7",
     "imports-loader": "^0.7.0",
     "indent-string": "^3.1.0",
+    "is-ci": "^1.0.10",
     "json-loader": "^0.5.3",
     "karma": "^1.5.0",
     "karma-browserstack-launcher": "^1.2.0",


### PR DESCRIPTION
Example of the verbose renderer when used for `obt test`:
```
[12:28:58] Testing SCSS silent styles [started]
[12:28:58] Testing SCSS silent styles [completed]
[12:28:58] Executing `npm test` [started]
[12:28:58] Executing `npm test` [skipped]
[12:28:58] Executing Pa11y [started]
[12:28:58] Executing Pa11y [skipped]
[12:28:58] → No Pa11y demo found. To run Pa11y against this project, create a file at /Users/jake.champion/Code/work/origami/components/o-forms/demos/local/pa11y.html
[12:28:58] Running Karma tests [started]
[12:28:58] Running Karma tests on Chrome Stable [title changed]
[12:28:58] Tests starting... [started]
[2017-10-09 12:28:59.326] [DEBUG] config - Loading config /Users/jake.champion/Code/oss/origami-build-tools/config/karma.config.chrome.js
[12:28:59] Starting Karma server [title changed]
[12:29:02] Running tests on HeadlessChrome 0.0.0 (Mac OS X 10.12.5) [title changed]
[12:29:02] Opening HeadlessChrome 0.0.0 (Mac OS X 10.12.5) [title changed]
[12:29:02] Starting tests on HeadlessChrome 0.0.0 (Mac OS X 10.12.5) [title changed]
[12:29:03] Completed tests on HeadlessChrome 0.0.0 (Mac OS X 10.12.5) [title changed]
[12:29:03] Completed tests on HeadlessChrome 0.0.0 (Mac OS X 10.12.5) [completed]
[12:29:03] Running Karma tests on Chrome Stable [completed]
```