### PR TITLE
Include bash color sequences in the tests

### DIFF
--- a/test/unit/plugins/listr-karma.test.js
+++ b/test/unit/plugins/listr-karma.test.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const colors = require('colors/safe');
 const proclaim = require('proclaim');
 
 const formatError = function (a, b) {
@@ -103,9 +104,9 @@ describe('SpecReporter', function () {
 
 					it('should add error message to the errors array', function () {
 						proclaim.deepEqual(errors, [
-							'Test Browser failed specs:',
-							'suite name > description of test',
-							'log message\t',
+							colors.white('Test Browser failed specs:'),
+							colors.white('suite name > description of test'),
+							colors.red('log message\t'),
 							'',
 							'1 tests failed across 1 browsers.'
 						]);
@@ -121,9 +122,9 @@ describe('SpecReporter', function () {
 						});
 
 						proclaim.deepEqual(errors, [
-							'Test Browser failed specs:',
-							'suite name > description of test',
-							'log message\t',
+							colors.white('Test Browser failed specs:'),
+							colors.white('suite name > description of test'),
+							colors.red('log message\t'),
 							'',
 							'1 tests failed across 1 browsers.'
 						]);


### PR DESCRIPTION
The color sequences are appearing in the tests. I've wrapped the test
strings with the expected color method, which means they should match
whether or not escape codes are added.