### PR TITLE
Require demo titles in origami.json.

### DIFF
--- a/lib/tasks/verify-origami-json.js
+++ b/lib/tasks/verify-origami-json.js
@@ -45,11 +45,11 @@ function origamiJson(config) {
 								result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
 							}
 
-							const hasNoTitle = componentDemos.some(function (demo) {
-								return ! Object.prototype.hasOwnProperty.call(demo, 'title');
+							const hasInvalidTitle = componentDemos.some(function (demo) {
+								return !(demo.title && typeof demo.title === 'string' && demo.title.trim().length > 0);
 							});
-							if (hasNoTitle) {
-								result.push('All demos require a title property.');
+							if (hasInvalidTitle) {
+								result.push('All demos require a title property which is non-empty and of type "string".');
 							}
 						}
 

--- a/lib/tasks/verify-origami-json.js
+++ b/lib/tasks/verify-origami-json.js
@@ -44,6 +44,13 @@ function origamiJson(config) {
 							if (hasExpanded) {
 								result.push('The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.');
 							}
+
+							const hasNoTitle = componentDemos.some(function (demo) {
+								return ! Object.prototype.hasOwnProperty.call(demo, 'title');
+							});
+							if (hasNoTitle) {
+								result.push('All demos require a title property.');
+							}
 						}
 
 						if (result.length > 0) {

--- a/test/unit/fixtures/o-test/origami.json
+++ b/test/unit/fixtures/o-test/origami.json
@@ -11,6 +11,7 @@
     },
     "demos": [
         {
+              "title": "Test module",
               "name": "pa11y",
               "template": "demos/src/pa11y.mustache",
               "description": "Pa11y test"

--- a/test/unit/tasks/verify-origami-json.test.js
+++ b/test/unit/tasks/verify-origami-json.test.js
@@ -372,23 +372,70 @@ describe('verify-origami-json', function () {
 				});
 		});
 
-		it('should fail when a demo does not have a title property', function () {
+		describe('demo title', function() {
 			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'origami.json'), 'utf-8'));
-			origamiJSON.demos = [{
-				'name': 'a name but no user friendly title for this demo'
-			}];
-			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+			origamiJSON.origamiType = 'module';
+			const expectedError = 'Failed linting:\n\n' +
+				'All demos require a title property which is non-empty and of type "string".\n\n' +
+				'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/';
 
-			return verifyOrigamiJson().task()
-				.catch(function (verifiedOrigamiJson) {
-					proclaim.equal(
-						verifiedOrigamiJson.message,
-						'Failed linting:\n\n' +
-						'All demos require a title property.\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
-					);
-				});
+			it('should fail when a demo does not have a title property', function () {
+				origamiJSON.demos = [{
+					name: 'a name but no user friendly title for this demo'
+				}];
+				fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+				return verifyOrigamiJson().task()
+					.then(function () {
+						proclaim.notOk(true, `origami.json validated when one of its demos is not a non-empty string`);
+					},
+					function (verifiedOrigamiJson) {
+						proclaim.equal(verifiedOrigamiJson.message, expectedError);
+					});
+			});
+
+			it('should fail when a demo has a empty title', function () {
+				origamiJSON.demos = [{
+					name: 'an unhelpful empty title for this demo',
+					title: ''
+				}];
+				fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+				return verifyOrigamiJson().task()
+					.then(function () {
+						proclaim.notOk(true, `origami.json validated when one of its demos is not a non-empty string`);
+					},
+					function (verifiedOrigamiJson) {
+						proclaim.equal(verifiedOrigamiJson.message, expectedError);
+					});
+			});
+
+			it('should fail when a demo has a blank title', function () {
+				origamiJSON.demos = [{
+					name: 'an unhelpful blank title for this demo',
+					title: ' '
+				}];
+				fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+				return verifyOrigamiJson().task()
+					.then(function () {
+						proclaim.notOk(true, `origami.json validated when one of its demos is not a non-empty string`);
+					},
+					function (verifiedOrigamiJson) {
+						proclaim.equal(verifiedOrigamiJson.message, expectedError);
+					});
+			});
+
+			it('should fail when a demo has a non-string title', function () {
+				origamiJSON.demos = [{
+					title: ['array here']
+				}];
+				fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+				return verifyOrigamiJson().task()
+					.then(function () {
+						proclaim.notOk(true, `origami.json validated when one of its demos is not a non-empty string`);
+					},function (verifiedOrigamiJson) {
+						proclaim.equal(verifiedOrigamiJson.message, expectedError);
+					});
+			});
+
 		});
 	});
-
 });

--- a/test/unit/tasks/verify-origami-json.test.js
+++ b/test/unit/tasks/verify-origami-json.test.js
@@ -430,7 +430,7 @@ describe('verify-origami-json', function () {
 				fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
 				return verifyOrigamiJson().task()
 					.then(function () {
-						proclaim.notOk(true, `origami.json validated when one of its demos is not a non-empty string`);
+						proclaim.notOk(true, `origami.json validated but one of its demos is not a non-empty string`);
 					},function (verifiedOrigamiJson) {
 						proclaim.equal(verifiedOrigamiJson.message, expectedError);
 					});

--- a/test/unit/tasks/verify-origami-json.test.js
+++ b/test/unit/tasks/verify-origami-json.test.js
@@ -353,8 +353,10 @@ describe('verify-origami-json', function () {
 		it('should fail when an expanded property is found for a demo', function () {
 			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'origami.json'), 'utf-8'));
 			origamiJSON.demos = [{
+				title: 'Expanded property in use.',
 				expanded: false
 			}, {
+				title: 'Expanded property in use.',
 				expanded: true
 			}];
 			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
@@ -365,6 +367,24 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.\n\n' +
+						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+					);
+				});
+		});
+
+		it('should fail when a demo does not have a title property', function () {
+			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'origami.json'), 'utf-8'));
+			origamiJSON.demos = [{
+				'name': 'a name but no user friendly title for this demo'
+			}];
+			fs.writeFileSync('origami.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyOrigamiJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'All demos require a title property.\n\n' +
 						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
 					);
 				});


### PR DESCRIPTION
Inline with the Origami spec and registry expectations.

All actively maintained Origami maintained `isOrigami` components should be covered when the PRs created today are merged. Deprecated or non-origami-maintained components will get caught by this new `obt verify` requirement.

Does this effect the build service?