### PR TITLE
Enable loaders to be resolved from a consuming applications node_modules folder

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const BowerResolvePlugin = require('bower-resolve-webpack-plugin');
+const appRoot = require('app-root-path');
 
 module.exports = {
 	// Fail out on the first error instead of tolerating it.
@@ -31,10 +32,13 @@ module.exports = {
 		// These extensions are tried when resolving a file
 		extensions: ['.js', '.json']
 	},
-	// Resolve loaders (webpack plugins) from the
-	// directory of `OBT` itself rather than the project directory.
 	resolveLoader: {
 		modules: [
+			// Resolve loaders from the project directory. This is used for Origami Build Service as dependencies are
+			// flattened by npm which causes the loaders to not be found.
+			appRoot + '/node_modules',
+			// Fallback to resolving loaders from OBT's node_modules folder if it has one. In most cases this is the
+			// resolver that will return the loaders.
 			path.resolve(__dirname, '../node_modules'),
 			'node_modules',
 			'bower_components'

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,6 +165,11 @@
         "normalize-path": "2.1.1"
       }
     },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y="
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1404,6 +1409,11 @@
         "supports-color": "4.4.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
     "check-types": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.0.1.tgz",
@@ -2297,12 +2307,11 @@
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dom-serialize": {
@@ -2657,32 +2666,32 @@
       }
     },
     "eslint": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
+      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.0",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.1.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -2700,6 +2709,22 @@
         "text-table": "0.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -2713,10 +2738,24 @@
             "ms": "2.0.0"
           }
         },
+        "espree": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+          "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+          "requires": {
+            "acorn": "5.3.0",
+            "acorn-jsx": "3.0.1"
+          }
+        },
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
           "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        },
+        "globals": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
         },
         "js-yaml": {
           "version": "3.10.0",
@@ -2880,6 +2919,11 @@
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
       }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "3.5.1",
@@ -3055,12 +3099,12 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "requires": {
+        "chardet": "0.4.2",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
         "tmp": "0.0.33"
       }
     },
@@ -3121,6 +3165,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -4692,7 +4741,7 @@
         "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -5077,11 +5126,6 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
-    "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -5145,6 +5189,11 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "aliases": "^0.1.0",
+    "app-root-path": "^2.0.1",
     "autoprefixer": "^7.1.5",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
This is used for Origami Build Service. When installing Origami Build Tools as a dependency, it's dependencies are deduped by npm which causes the loaders to not be found because they are no longer under the origami-build-tools folder (they are within the consuming applications node_modules folder).