### PR TITLE
Make obt test work with npx

### DIFF
--- a/lib/helpers/command-line.js
+++ b/lib/helpers/command-line.js
@@ -8,6 +8,9 @@ function run(command, args, options) {
 	const opts = {
 		cwd: options.cwd || process.cwd()
 	};
+	if (options.localDir) {
+		opts.localDir = options.localDir;
+	}
 	if (options && options.stdout === undefined && options.stderr === undefined) {
 		opts.stdio = 'inherit';
 	}

--- a/lib/tasks/test-sass.js
+++ b/lib/tasks/test-sass.js
@@ -17,7 +17,7 @@ const trueTest = function (config) {
 		const sassTrue = require('${require.resolve('sass-true')}');
 		sassTrue.runSass({file: sassFile}, describe, it);
 	`)
-		.then(() => commandLine.run('mocha', ['test/scss'], config))
+		.then(() => commandLine.run('mocha', ['test/scss'], Object.assign({}, config, { localDir: path.join(__dirname, "../../")})))
 		.finally(() => unlink(testRunner));
 };
 


### PR DESCRIPTION
`npx origami-build-tools test` currently fails because `execa` can not find `mocha`. This is because `npx` installs modules into a directory that `execa` doesn't look into. We can tell `execa` where to look using the `localDir` option.