### PR TITLE
Reformat SASS build error to include file, line, and column.

### DIFF
--- a/lib/tasks/build-sass.js
+++ b/lib/tasks/build-sass.js
@@ -116,6 +116,13 @@ module.exports = function buildSass(config) {
 							} else {
 								return css;
 							}
+						})
+						.catch((error) => {
+							throw new Error(
+								'Failed building SASS:\n' +
+								`${error.message}\n` +
+								`${error.file}:${error.line}:${error.column}`
+							);
 						});
 				});
 		}


### PR DESCRIPTION
Before and after:

<img width="1152" alt="screen shot 2018-05-16 at 15 39 00" src="https://user-images.githubusercontent.com/10405691/40124045-8a923622-591f-11e8-9645-22c0c400c26e.png">
