### PR TITLE
Update True SCSS tests path.

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -148,7 +148,7 @@ function getSassTestFiles(cwd) {
 		cwd: cwd || process.cwd()
 	};
 
-	return deglob([`/test/scss/**/**.test.scss`, `/test/scss/**.test.scss`], opts);
+	return deglob([`test/scss/**/**.test.scss`, `test/scss/**.test.scss`], opts);
 }
 
 function sassSupportsSilent(files, cwd) {


### PR DESCRIPTION
SCSS tests are not discovered currently (e.g. [o-brand tests](https://github.com/Financial-Times/o-brand/tree/master/test/scss)).

<img width="739" alt="screen shot 2018-05-23 at 10 58 03" src="https://user-images.githubusercontent.com/10405691/40417681-37c018a2-5e78-11e8-97fa-ebe1256d6a9f.png">
