### PR TITLE
Fix publishing from circle ci 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,18 @@ workflows:
   version: 2
   node-multi-build:
     jobs:
-      - node-v6
-      - node-v8
-      - node-v10
+      - node-v6:
+          filters:
+            tags:
+              only: /^v.*/
+      - node-v8:
+          filters:
+            tags:
+              only: /^v.*/
+      - node-v10:
+          filters:
+            tags:
+              only: /^v.*/
       - publish:
           requires:
             - node-v6


### PR DESCRIPTION
As per the docs -- https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#git-tag-job-execution---deploy-on-tagged-commit