### PR TITLE
Add port flag to obt.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,67 +6,46 @@ ignore:
     - karma > chokidar > anymatch > micromatch > braces:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      chokidar > anymatch > micromatch > braces:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > expand-braces > braces:
         reason: Will update to newer karma which will fix this
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > chokidar > anymatch > micromatch > braces:
-        reason: None given
-        expires: '2018-08-29T18:14:24.725Z'
     - karma-browserstack-launcher > karma > expand-braces > braces:
         reason: will updaet to newer karma which will fix this
         expires: '2018-08-29T17:52:20.470Z'
-      karma-sinon > karma > chokidar > anymatch > micromatch > braces:
-        reason: None given
-        expires: '2018-08-29T18:14:24.725Z'
     - karma-sinon > karma > expand-braces > braces:
         reason: Will update to newer karma which will fix this
         expires: '2018-08-29T17:52:20.470Z'
+    - chokidar > anymatch > micromatch > braces:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > chokidar > anymatch > micromatch > braces:
+        reason: None given
+        expires: '2018-08-29T18:14:24.725Z'
+    - karma-sinon > karma > chokidar > anymatch > micromatch > braces:
+        reason: None given
+        expires: '2018-08-29T18:14:24.725Z'
   'npm:debug:20170905':
     - karma > socket.io > engine.io > debug:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > debug:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > socket.io-adapter > debug:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > engine.io > debug:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > socket.io-client > debug:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-adapter > debug:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > socket.io-client > engine.io-client > debug:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-client > debug:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > socket.io-parser > debug:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-client > engine.io-client > debug:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > debug:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-parser > debug:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > socket.io-client > socket.io-parser > debug:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-client > socket.io-parser > debug:
-        reason: None given
-        expires: '2018-08-29T18:14:24.725Z'
     - karma-sinon > karma > socket.io > socket.io-client > socket.io-parser > debug:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
@@ -88,68 +67,68 @@ ignore:
     - karma-sinon > karma > socket.io > debug:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
+    - karma-browserstack-launcher > karma > socket.io > debug:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > engine.io > debug:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-adapter > debug:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-client > debug:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-client > engine.io-client > debug:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-parser > debug:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-client > socket.io-parser > debug:
+        reason: None given
+        expires: '2018-08-29T18:14:24.725Z'
   'npm:ws:20171108':
     - karma > socket.io > socket.io-client > engine.io-client > ws:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-client > engine.io-client > ws:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > engine.io > ws:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > engine.io > ws:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma-sinon > karma > socket.io > socket.io-client > engine.io-client > ws:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
     - karma-sinon > karma > socket.io > engine.io > ws:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-client > engine.io-client > ws:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > engine.io > ws:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
   'npm:ms:20170412':
     - karma > socket.io > socket.io-client > socket.io-parser > debug > ms:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-client > socket.io-parser > debug > ms:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > socket.io-parser > debug > ms:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-parser > debug > ms:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > socket.io-client > engine.io-client > debug > ms:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-client > engine.io-client > debug > ms:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > debug > ms:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-client > debug > ms:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma > socket.io > engine.io > debug > ms:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > socket.io-adapter > debug > ms:
-        reason: None given
-        expires: '2018-08-29T18:14:24.725Z'
     - karma > socket.io > socket.io-adapter > debug > ms:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > engine.io > debug > ms:
-        reason: None given
-        expires: '2018-08-29T18:14:24.725Z'
     - karma > socket.io > socket.io-client > debug > ms:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > socket.io > debug > ms:
-        reason: None given
-        expires: '2018-08-29T18:14:24.725Z'
     - karma-sinon > karma > socket.io > socket.io-client > debug > ms:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
@@ -171,24 +150,45 @@ ignore:
     - karma-sinon > karma > socket.io > socket.io-client > socket.io-parser > debug > ms:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-client > socket.io-parser > debug > ms:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-parser > debug > ms:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-client > engine.io-client > debug > ms:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-client > debug > ms:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
+    - karma-browserstack-launcher > karma > socket.io > socket.io-adapter > debug > ms:
+        reason: None given
+        expires: '2018-08-29T18:14:24.725Z'
+    - karma-browserstack-launcher > karma > socket.io > engine.io > debug > ms:
+        reason: None given
+        expires: '2018-08-29T18:14:24.725Z'
+    - karma-browserstack-launcher > karma > socket.io > debug > ms:
+        reason: None given
+        expires: '2018-08-29T18:14:24.725Z'
   'npm:lodash:20180130':
     - karma > lodash:
         reason: It is a big breaking change in karma
         expires: '2018-08-29T17:52:20.470Z'
-      karma-browserstack-launcher > karma > lodash:
-        reason: None given
-        expires: '2018-08-29T18:14:24.724Z'
     - karma-sinon > karma > lodash:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
+    - karma-browserstack-launcher > karma > lodash:
+        reason: None given
+        expires: '2018-08-29T18:14:24.724Z'
   'npm:cryptiles:20180710':
     - karma-scss-preprocessor > node-sass > node-gyp > request > hawk > cryptiles:
         reason: Will update to newer karma which will fix this
         expires: '2018-08-29T17:52:20.470Z'
-      node-sass > node-gyp > request > hawk > cryptiles:
+    - sass-true > node-sass > node-gyp > request > hawk > cryptiles:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
-    - sass-true > node-sass > node-gyp > request > hawk > cryptiles:
+    - node-sass > node-gyp > request > hawk > cryptiles:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
   'npm:parsejson:20170908':
@@ -227,6 +227,10 @@ ignore:
     - sass-lint > eslint > shelljs:
         reason: None given
         expires: '2018-08-29T18:14:24.725Z'
+  'npm:serve:20180529':
+    - serve:
+        reason: Vulnerability isn't exploitable on production systems
+        expires: '2018-09-28T11:36:47.937Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:tunnel-agent:20170305':

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -30,7 +30,7 @@ const help = `
 			-h, --help                 Print out this message
 			--watch                    Re-run every time a file changes
 			--run-server               Build demos locally and runs a server
-			--port=<port>              The port to run the local server on.
+			--port=<port>              The port to run the local server on if available (default: 8999).
 			--js=<path>                Main JavaScript file (default: ./src/main.js)
 			--sass=<path>              Main Sass file (default: ./src/main.scss)
 			--build-js=<file>          Compiled JavaScript file (default: main.js)

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -30,6 +30,7 @@ const help = `
 			-h, --help                 Print out this message
 			--watch                    Re-run every time a file changes
 			--run-server               Build demos locally and runs a server
+			--port=<port>              The port to run the local server on.
 			--js=<path>                Main JavaScript file (default: ./src/main.js)
 			--sass=<path>              Main Sass file (default: ./src/main.scss)
 			--build-js=<file>          Compiled JavaScript file (default: main.js)
@@ -55,7 +56,7 @@ const cli = meow(help, {
 let server;
 if (cli.flags.runServer) {
 	server = serve(cli.flags.cwd || process.cwd(), {
-		port: 8999,
+		port: cli.flags.port || 8999,
 		ignore: ['node_modules']
 	});
 }


### PR DESCRIPTION
`obt demo --run-server --port=3002`

Requested for `o-ads`, to run custom tests against browserstack which requires a certain port for IOS: https://www.browserstack.com/question/664