### PR TITLE
Make the error message for the silent mode test more helpful.

### DIFF
--- a/lib/tasks/sass.js
+++ b/lib/tasks/sass.js
@@ -51,11 +51,11 @@ function silentCompilationTest(silent, cwd) {
 														silent: silent
 													})(css);
 												})
-												.catch(() => {
+												.catch((error) => {
 													if (silent) {
-														throw new Error(`When compiling with \`${sassVar}\` styles were output when they should not have been`);
+														throw new Error(`When compiling with \`${sassVar}\` styles were output when they should not have been: ${error.message}`);
 													} else {
-														throw new Error(`When compiling with \`${sassVar}\` no styles were output when the should have been`);
+														throw new Error(`When compiling with \`${sassVar}\` no styles were output when the should have been: ${error.message}`);
 													}
 												});
 										});


### PR DESCRIPTION
<img width="1205" alt="screen shot 2018-08-29 at 15 39 47" src="https://user-images.githubusercontent.com/10405691/44795231-234b7700-aba2-11e8-84c4-26199da7814e.png">

Now:
>When compiling with `$o-footer-services-is-silent: false;` no styles were output when the should have been: Failed building SASS:
'null' is not a valid base color.

Previous:
>When compiling with `$o-footer-services-is-silent: false;` no styles were output when the should have been