### PR TITLE
Added TODO-comment-finding eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ const origamiServicesConfig = merge({},
 		"rules": {
 			"no-console": "off",
 			"no-await-in-loop": "off",
+			"no-warning-comments": "warn",
 
 			"filenames/match-regex": [2, "^[a-z0-9-]+(\.test|(\.config(\.browserstack|\.dev|\.chrome|\.prod)?))?$", true],
 


### PR DESCRIPTION
The added rule will report any `//TODO`, `//FIXME` and `//xxx` code comments as linting warnings.

It will make and OBT-dependant project that uses OBT's eslint rules (e.g., `o-ads` is doing this now), to report those to-do comments.

Interesting fact: linting OBT itself is currently reporting 5 of those comments.