### PR TITLE
Update the default support details

### DIFF
--- a/templates/component-boilerplate/origami-json.js
+++ b/templates/component-boilerplate/origami-json.js
@@ -9,10 +9,10 @@ module.exports = (name) => {
 	"origamiVersion": 1,
 	"support": "https://github.com/Financial-Times/${name.original}/issues",
 	"supportContact": {
-		"email": "origami.support@ft.com",
-		"slack": "financialtimes/ft-origami"
+		"email": "YOUR-TEAM@ft.com",
+		"slack": "financialtimes/YOUR-SLACK-CHANNEL"
 	},
-	"supportStatus": "active",
+	"supportStatus": "experimental",
 	"browserFeatures": {},
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/Financial-Times/${name.original}"


### PR DESCRIPTION
Currently `obt init` generates an `origami.json` file that specifies a
support status of "active" and support contact details which point to
the Origami team.

This means that the responsibility for marking a new component as
experimental or maintained by another team is on the person creating a
component. This makes work for us, as we have to remind a non-Origami
developer to update these fields before publishing, and it's possible
(even likely) that an unsupported component will appear in the registry
as "actively maintained by the Origami team".

This PR updates the template to provide sensible details for users who
aren't as familiar with Origami. Members of the Origami team who create
new components are more likely to check and update this information as
required without prompting.