### PR TITLE
Let's use npm ci instead of npm i

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,36 +24,6 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-references:
-  restore_npm_cache: &restore_npm_cache
-    restore_cache:
-      keys:
-        - npm-lock-{{ checksum "package-lock.json" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
-        - npm-lock-{{ checksum "package-lock.json" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}
-        - npm-cache-{{ checksum "package.json" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
-        - npm-cache-{{ checksum "package.json" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}
-  versions: &versions
-    run:
-      name: Versions
-      command: npm version
-  install: &install
-    run:
-      name: Install dependencies
-      command: npm install
-  test: &test
-    run:
-      name: Test
-      command: make ci
-  save_cache_local: &save_cache_local
-    save_cache:
-      key: npm-lock-{{ checksum "package-lock.json" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
-      paths:
-        - node_modules
-  save_cache_global: &save_cache_global
-    save_cache:
-      key: npm-cache-{{ checksum "package.json" }}-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
-      paths:
-        - ~/.npm/_cacache
 
 version: 2
 jobs:
@@ -61,13 +31,9 @@ jobs:
     docker:
       - image: circleci/node:latest-browsers
     steps:
-      - *versions
       - checkout
-      - *restore_npm_cache
-      - *install
-      - *test
-      - *save_cache_local
-      - *save_cache_global
+      - run: npm ci || npm i
+      - run: make ci
   node-v6:
     <<: *node-base
     docker:
@@ -86,13 +52,9 @@ jobs:
     docker:
       - image: circleci/node:6-browsers
     steps:
-      - *versions
       - checkout
-      - *restore_npm_cache
-      - *install
-      - *test
-      - *save_cache_local
-      - *save_cache_global
+      - run: npm ci || npm i
+      - run: make ci
       - run:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@financial-times/origami-service-makefile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.2.0.tgz",
-      "integrity": "sha1-zQIf+HgjQYQZDbAg0GoiqX7Nafs=",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-6.4.0.tgz",
+      "integrity": "sha512-BAta9ElfKENOO+WTLNxmFu75uO+bImxXt20YWsHJTGEg4VzKTUMjXv77yDx5uc8mLJVuEiGNXJvNg2XMWxxT1Q==",
       "dev": true,
       "requires": {
         "esm": "^3.0.18"
@@ -3704,9 +3704,9 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "esm": {
-      "version": "3.0.72",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.72.tgz",
-      "integrity": "sha512-xmh7Ay/71Wl41EPM3FVomp/GZKMgEGoo3x/qWdbGi+0DODbte+2l1sSXAiDKahBQn0zioG30ZNJTkxz08pEsMw==",
+      "version": "3.0.84",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
+      "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw==",
       "dev": true
     },
     "espree": {


### PR DESCRIPTION
The master branch had a package-lock.json which was out-of-sync with package.json, we can ensure that never happens by using `npm ci` in CircleCI instead of `npm i`. Using `npm ci` has an added benefit of simplifying the CircleCI config because it guarantees that the node_modules folder will be the same.