### PR TITLE
Only build supported brand SCSS

### DIFF
--- a/config/karma.config.js
+++ b/config/karma.config.js
@@ -6,9 +6,10 @@ const fileHelpers = require('../lib/helpers/files');
 // https://github.com/webpack/webpack/issues/3324#issuecomment-289720345
 delete webpackConfig.bail;
 module.exports.getBaseKarmaConfig = function() {
-	return Promise.all([fileHelpers.getModuleName(), fileHelpers.readIfExists(path.resolve('main.scss'))]).then(values => {
+	return Promise.all([fileHelpers.getModuleName(), fileHelpers.getModuleBrands(), fileHelpers.readIfExists(path.resolve('main.scss'))]).then(values => {
 		const moduleName = values[0];
-		const mainScssContent = values[1];
+		const brands = values[1];
+		const mainScssContent = values[2];
 		return {
 			// enable / disable watching file and executing tests whenever any file changes
 			autoWatch: false,
@@ -72,7 +73,7 @@ module.exports.getBaseKarmaConfig = function() {
 			scssPreprocessor: {
 				options: {
 					file: '',
-					data: `$${moduleName}-is-silent: false; ${mainScssContent}`,
+					data: `${brands.length ? `$o-brand: ${brands[0]};` : ''}$${moduleName}-is-silent: false; ${mainScssContent}`,
 					includePaths: [process.cwd(), path.join(process.cwd(), 'bower_components')]
 				}
 			},

--- a/lib/tasks/test-sass-compilation.js
+++ b/lib/tasks/test-sass-compilation.js
@@ -59,22 +59,30 @@ module.exports = function (cfg) {
 	config.cwd = config.cwd || process.cwd();
 
 	return files.getModuleBrands().then((brands) => {
-		const brandCompilationTests = brands.map(brand => {
-			return {
-				title: `Testing SCSS compilation for the ${brand} brand`,
-				task: () => compilationTest(config.cwd, { brand }),
-				skip: () => !files.getMainSassPath(config.cwd)
-			};
-		});
 
-		return [{
+		const silientModeTest = {
 			title: 'Testing SCSS compilation with silent mode on',
 			task: () => compilationTest(config.cwd, { silent: true }),
 			skip: () => !files.getMainSassPath(config.cwd)
-		}, {
-			title: 'Testing SCSS compilation with silent mode off',
-			task: () => compilationTest(config.cwd, { silent: false }),
-			skip: () => !files.getMainSassPath(config.cwd)
-		}, ...brandCompilationTests];
+		};
+
+		if (brands.length === 0) {
+			return [silientModeTest, {
+				title: 'Testing SCSS compilation with silent mode off',
+				task: () => compilationTest(config.cwd, { silent: false }),
+				skip: () => !files.getMainSassPath(config.cwd)
+			}];
+		}
+
+		return [silientModeTest, ...brands.map(brand => {
+			return {
+				title: `Testing SCSS compilation for the ${brand} brand`,
+				task: () => compilationTest(config.cwd, {
+					brand,
+					silent: false
+				}),
+				skip: () => !files.getMainSassPath(config.cwd)
+			};
+		})];
 	});
 };


### PR DESCRIPTION
OBT always tests component SCSS can compile for the master brand, because it used to be required. However that isn't true anymore, so OBT should only test compilation for brands specified within a component's `origami.json`.