### PR TITLE
Allow SCSS builds with no content.

### DIFF
--- a/lib/plugins/silent-sass.js
+++ b/lib/plugins/silent-sass.js
@@ -2,9 +2,6 @@
 
 module.exports = function silentSass(config) {
 	return function (css) {
-		if (!config.silent && css.length === 0) {
-			throw new Error('CSS was not output with silent mode off.');
-		}
 		if (config.silent && css.length !== 0) {
 			throw new Error('CSS was output with silent mode on.');
 		}

--- a/test/unit/plugins/silent-sass.test.js
+++ b/test/unit/plugins/silent-sass.test.js
@@ -31,14 +31,4 @@ describe('Silent Sass', function () {
 			silent: true
 		})(fakeFile));
 	});
-
-	it('Should fail if silent is false and file does not have content', function () {
-		const fakeFile = Buffer.from('');
-
-		const mySilentSass = silentSass({
-			silent: false
-		});
-
-		proclaim.throws(() => mySilentSass(fakeFile), 'CSS was not output with silent mode off.');
-	});
 });


### PR DESCRIPTION
Since introducing branded components it is possible for a CSS build to have no content. For example [see o-fonts](https://github.com/Financial-Times/o-fonts/pull/90), where the whitelabel brand outputs no font faces by default but its scss mixins are still useful. With this update OBT will no longer error when CSS is built with no content. Instead we can use [True](https://github.com/oddbird/true) within our components to validate output.

I can't think of a good alternative, except for complicating origami.json to indicate when we expect output or not. 😷