### PR TITLE
Add brand query param to demo dependencies.

### DIFF
--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -182,7 +182,7 @@ function buildHtml(buildConfig) {
 
 			return Promise.all([
 				files.getModuleName(buildConfig.cwd),
-				getStylesheetTags(buildConfig.demo.sass, buildConfig.demo.dependencies, buildConfig.staticSource, buildConfig.cwd),
+				getStylesheetTags(buildConfig.demo.sass, buildConfig.demo.dependencies, buildConfig.staticSource, buildConfig.cwd, buildConfig.brand),
 				getScriptTags(buildConfig.demo.js, buildConfig.demo.dependencies, buildConfig.staticSource, buildConfig.cwd),
 				readFile(src, {
 					encoding: 'utf8'
@@ -264,12 +264,12 @@ function loadPartials(partialsDir) {
 		});
 }
 
-function getStylesheetTags(sassPath, dependencies, staticSource, cwd) {
+function getStylesheetTags(sassPath, dependencies, staticSource, cwd, brand) {
 	return Promise.resolve('')
 		.then((stylesheets) => {
 			if (staticSource !== 'dist') {
 				if (dependencies) {
-					stylesheets += '<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=' + dependencies.toString() + '" />\n\t';
+					stylesheets += `<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=${dependencies.toString()}${brand ? `&brand=${brand}` : ''}" />\n\t`;
 				}
 				if (sassPath) {
 					stylesheets += '<link rel="stylesheet" href="' + path.basename(sassPath).replace('.scss', '.css') + '" />';


### PR DESCRIPTION
We do this in [an old version of OBT](https://github.com/Financial-Times/origami-build-tools/compare/v5.7.1...v5.8.0) which the build service uses, but not in the newer version of OBT. Save us OAT 🙈 