### PR TITLE
Print a helpful error if the user hasn't supplied required keys

### DIFF
--- a/lib/tasks/karma.js
+++ b/lib/tasks/karma.js
@@ -8,6 +8,16 @@ const { getBrowserStackKarmaConfig } = require('../../config/karma.config.browse
 const { getChromeKarmaConfig } = require('../../config/karma.config.chrome.js');
 
 const karmaTest = function (config, task) {
+	if (config.browserstack) {
+		const {
+			BROWSER_STACK_USERNAME,
+			BROWSER_STACK_ACCESS_KEY
+		} = process.env;
+
+		if (BROWSER_STACK_USERNAME == null || BROWSER_STACK_ACCESS_KEY == null) {
+			return Promise.reject(new Error("Required environment variables (BROWSER_STACK_USERNAME, BROWSER_STACK_ACCESS_KEY) not supplied"));
+		}
+	}
 	const getCustomKarmaConfig = config.browserstack ? getBrowserStackKarmaConfig : getChromeKarmaConfig;
 	return Promise.all([constructPolyfillUrl(), getCustomKarmaConfig(config)]).then(values => {
 		const polyfillUrl = values[0];

--- a/lib/tasks/karma.js
+++ b/lib/tasks/karma.js
@@ -14,7 +14,7 @@ const karmaTest = function (config, task) {
 			BROWSER_STACK_ACCESS_KEY
 		} = process.env;
 
-		if (BROWSER_STACK_USERNAME == null || BROWSER_STACK_ACCESS_KEY == null) {
+		if (!BROWSER_STACK_USERNAME || !BROWSER_STACK_ACCESS_KEY) {
 			return Promise.reject(new Error("Required environment variables (BROWSER_STACK_USERNAME, BROWSER_STACK_ACCESS_KEY) not supplied"));
 		}
 	}


### PR DESCRIPTION
----

Before this, the browserstack tests would print:

``` text
  ❯ Running Karma tests on BrowserStack
    ✖ Starting Karma server
      → Failed Karma tests:
      →
      →
```

and then fail :(((((((


now it prints this!:

``` text
  ❯ Running Karma tests on BrowserStack
    ✖ Tests starting...
      → Required environment variables (BROWSER_STACK_USERNAME, BROWSER_STACK_ACCESS_KEY) not supplied

```

and then fail :)))))))))