### PR TITLE
Upgrade minimum browser versions to match doc enhanced support

### DIFF
--- a/config/karma.config.browserstack.js
+++ b/config/karma.config.browserstack.js
@@ -12,7 +12,7 @@ const customLaunchers = {
 		base: 'BrowserStack',
 		browser: 'firefox',
 		os: 'OS X',
-		os_version: 'Sierra'
+		os_version: 'Mojave'
 	},
 
 	// Chrome latest
@@ -20,15 +20,15 @@ const customLaunchers = {
 		base: 'BrowserStack',
 		browser: 'chrome',
 		os: 'OS X',
-		os_version: 'Sierra'
+		os_version: 'Mojave'
 	},
 
-	// Safari 10
+	// Safari latest
 	bs_safari: {
 		base: 'BrowserStack',
 		browser: 'safari',
 		os: 'OS X',
-		os_version: 'Sierra'
+		os_version: 'High Sierra'
 	},
 
 	// IE 11
@@ -47,20 +47,20 @@ const customLaunchers = {
 		os_version: '10'
 	},
 
-	// iOS 8
-	bs_iphone6: {
+	// iOS 10
+	bs_iphone7: {
 		base: 'BrowserStack',
-		device: 'iPhone 6',
+		device: 'iPhone 7',
 		os: 'ios',
-		os_version: '8.3'
+		os_version: '10'
 	},
 
-	// Android 4.4
-	bs_android4_4: {
+	// Android 5
+	bs_android5: {
 		base: 'BrowserStack',
 		os: 'android',
-		device: 'Samsung Galaxy S5',
-		os_version: '4.4'
+		device: 'Google Nexus 6',
+		os_version: '5.0'
 	}
 };
 

--- a/config/karma.config.browserstack.js
+++ b/config/karma.config.browserstack.js
@@ -4,8 +4,8 @@ const constants = require('karma').constants;
 const customLaunchers = {
 	// If browser_version is not set, uses latest stable version
 
-	// Tesing on minimum version for enhanced experience based on
-	// https://docs.google.com/document/d/1mByh6sT8zI4XRyPKqWVsC2jUfXHZvhshS5SlHErWjXU
+	// Testing on minimum version for enhanced experience based on
+	// https://docs.google.com/document/d/1AG4uZEFiWOkXfy0pdE3-3NCUP2No4MkoiZMLlJnO5lI/edit?ts=5d498574
 
 	// Firefox latest
 	bs_firefox: {


### PR DESCRIPTION
Mostly the same as this, except without Samsung browser (we can't) and using iOS
Safari 10 instead of iOS Safari 9 (we can't test iOS 9)

https://docs.google.com/document/d/1AG4uZEFiWOkXfy0pdE3-3NCUP2No4MkoiZMLlJnO5lI/edit?ts=5d498574