### PR TITLE
Set the system code variable when building Sass.

### DIFF
--- a/lib/tasks/build-sass.js
+++ b/lib/tasks/build-sass.js
@@ -49,9 +49,10 @@ module.exports = function buildSass(config) {
 			} else {
 				const sassPrefix = config.sassPrefix || '';
 				const sassBrandVariable = config.brand ? `$o-brand: ${config.brand};` : '';
+				const sassSystemCodeVariable = '$system-code: "origami-build-tools";';
 				sassConfig = readFile(sassFile, 'utf-8').then(code => {
 					// Sass prefixing is used in our origami component specification sass tests
-					return { data: sassBrandVariable + sassPrefix + code };
+					return { data: sassSystemCodeVariable + sassBrandVariable + sassPrefix + code };
 				});
 			}
 


### PR DESCRIPTION
Soon our components will require a `$system-code` variable to build. 
e.g. https://github.com/Financial-Times/o-footer-services/issues/10
Set the system code to `origami-build-tools` when working on components locally.
