### PR TITLE
Make Sass errors more useful.

### DIFF
--- a/lib/tasks/build-sass.js
+++ b/lib/tasks/build-sass.js
@@ -120,7 +120,7 @@ module.exports = function buildSass(config) {
 						.catch((error) => {
 							throw new Error(
 								'Failed building SASS:\n' +
-								`${error.message}\n` +
+								`${error.formatted || error.message}\n` +
 								`${error.file}:${error.line}:${error.column}`
 							);
 						});


### PR DESCRIPTION
Before
<img width="783" alt="Screenshot 2019-10-03 at 12 23 03" src="https://user-images.githubusercontent.com/10405691/66122835-a676a200-e5d8-11e9-94ff-9d541419cb03.png">

After
<img width="955" alt="Screenshot 2019-10-03 at 12 22 43" src="https://user-images.githubusercontent.com/10405691/66122845-ac6c8300-e5d8-11e9-9178-47fec62def3f.png">
