### PR TITLE
Remove custom class name variable from Sass boilerplate.

### DIFF
--- a/templates/component-boilerplate/src-sass-mixins.js
+++ b/templates/component-boilerplate/src-sass-mixins.js
@@ -2,8 +2,8 @@
 
 module.exports = (name) => {
 	return `/// Output All oMessage Features
-@mixin ${name.camelCase} ($class: '${name.original}') {
-	.#{$class} {
+@mixin ${name.camelCase}() {
+	.${name.original} {
 		display: block;
 	}
 }

--- a/templates/component-boilerplate/src-sass-mixins.js
+++ b/templates/component-boilerplate/src-sass-mixins.js
@@ -1,12 +1,12 @@
 'use strict';
 
 module.exports = (name) => {
-	return `/// Output All oMessage Features
+	return `/// Output All ${name.camelCase} Features
 @mixin ${name.camelCase}() {
 	.${name.original} {
 		display: block;
 	}
-}
+};
 
 /// Provide a component specific error message
 ///


### PR DESCRIPTION
Relates to proposal: https://github.com/Financial-Times/origami-proposals/issues/4
And the major cascade project, where we are removing custom Sass classes:
https://github.com/orgs/Financial-Times/projects/77