### PR TITLE
Only include explicitly required polyfills in demos.

### DIFF
--- a/lib/helpers/construct-polyfill-url.js
+++ b/lib/helpers/construct-polyfill-url.js
@@ -29,9 +29,9 @@ function constructBrowserDeps() {
 		.then(requiredFeatures => {
 			const features = Array.from(new Set(requiredFeatures));
 			if (features.length > 0) {
-				return `https://polyfill.io/v2/polyfill.js?features=default,${features.join(',')}&flags=gated&unknown=polyfill`;
+				return `https://polyfill.io/v2/polyfill.js?features=,${features.join(',')}&flags=gated&unknown=polyfill`;
 			} else {
-				return 'https://polyfill.io/v2/polyfill.js?features=default&flags=gated&unknown=polyfill';
+				return 'https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill';
 			}
 		});
 }

--- a/test/unit/helpers/construct-polyfill-url.test.js
+++ b/test/unit/helpers/construct-polyfill-url.test.js
@@ -62,7 +62,7 @@ describe('construct-polyfill-url', function() {
 			globby.resolves([]);
 			return constructPolyfillUrl()
 				.then(polyfillUrl => {
-					expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=default&flags=gated&unknown=polyfill');
+					expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
 				});
 		});
 	});
@@ -75,7 +75,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=default&flags=gated&unknown=polyfill');
+						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -87,7 +87,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=default&flags=gated&unknown=polyfill');
+						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -99,7 +99,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=default,Array.prototype.every&flags=gated&unknown=polyfill');
+						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=,Array.prototype.every&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -110,7 +110,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=default,Array.prototype.every,Array.prototype.some&flags=gated&unknown=polyfill');
+						expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=,Array.prototype.every,Array.prototype.some&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -121,7 +121,7 @@ describe('construct-polyfill-url', function() {
 
 					return constructPolyfillUrl()
 						.then(polyfillUrl => {
-							expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?features=default&flags=gated&unknown=polyfill');
+							expect(polyfillUrl).to.equal('https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
 						});
 				});
 			});


### PR DESCRIPTION
Otherwise this can give the false impression a component works
in a browser without polyfills. Only polyfills requested in
`origami.json` (`browserFeatures.required`) should be included.

https://github.com/Financial-Times/origami-build-tools/issues/622