### PR TITLE
v5 backport: Only include explicitly required polyfills in demos.

### DIFF
--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -130,7 +130,6 @@ function buildHtml(gulp, buildConfig) {
 			.concat(origamiJson.browserFeatures.required || [])
 			.concat(origamiJson.browserFeatures.optional || []);
 	}
-	browserFeatures.push('default');
 	data.oDemoBrowserFeatures = browserFeatures;
 
 	const partials = loadPartials(partialsDir);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "origami-build-tools",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origami-build-tools",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "description": "Origami component development tools.",
   "main": "./lib/origami-build-tools",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origami-build-tools",
-  "version": "5.8.0",
+  "version": "5.8.2",
   "description": "Origami component development tools.",
   "main": "./lib/origami-build-tools",
   "bin": {


### PR DESCRIPTION
Otherwise this can give the false impression a component works
in a browser without polyfills. Only polyfills requested in
`origami.json` (`browserFeatures.required`) should be included.

https://github.com/Financial-Times/origami-build-tools/issues/622

This backport to v5 brings this change to the Build Service demos.