### PR TITLE
Revert "Fallback to npm name if bower name is missing"

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -121,23 +121,13 @@ function getMainJsPath(cwd) {
 }
 
 function getModuleName(cwd) {
-	const getNameFromJson = json => {
-		if (json) {
-			return json.name;
-		}
-		return '';
-	};
-
-	const bowerName = getBowerJson(cwd)
-		.then(getNameFromJson);
-
-	const npmName = getPackageJson(cwd)
-		.then(getNameFromJson);
-
-	return Promise.all([bowerName, npmName])
-		.then(([bowerName, npmName]) =>
-			bowerName || npmName
-		);
+	return getBowerJson(cwd)
+		.then(bowerJson => {
+			if (bowerJson) {
+				return bowerJson.name;
+			}
+			return '';
+		});
 }
 
 function getModuleBrands(cwd) {


### PR DESCRIPTION
This doesn't work because the post-occ's npm name is `@financial-times/whatever`