### PR TITLE
Only build Sass once when shared by multiple demos.

### DIFF
--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -15,57 +15,53 @@ const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(
 const readFile = denodeify(fs.readFile);
 const outputFile = denodeify(fs.outputFile);
 
-const builtFiles = {};
-
 function buildSass(buildConfig) {
 	const src = path.join(buildConfig.cwd, '/' + buildConfig.demo.sass);
 	const dest = path.join(buildConfig.cwd, '/demos/local/');
-	if (!builtFiles.css.includes(src)) {
-		return fileExists(src)
-			.then(exists => {
-				if (!exists) {
-					const e = new Error('Sass file not found: ' + src);
-					e.stack = '';
-					throw e;
-				}
-				return files.getBowerJson(buildConfig.cwd);
-			})
-			.then(bowerConfig => {
-				let prefixSass = '';
-				// If module has o-assets as a dependency, set local demos to use local assets
-				// to use the latest ones in the repo
-				if (bowerConfig && bowerConfig.dependencies && bowerConfig.dependencies['o-assets']) {
-					const moduleName = bowerConfig.name;
-					prefixSass = '@import \'o-assets/main\';\n' +
-						'@include oAssetsSetModulePaths((' + moduleName + ': ""));\n';
-				}
 
-				builtFiles.css.push(src);
-				const sassConfig = {
-					sass: src,
-					sassPrefix: prefixSass,
-					// For the Sass files to load correctly, they need to be in one of these two directories.
-					// Sass doesn't look in subdirectories and we can't use wildcards
-					sassIncludePaths: ['demos/src', 'demos/src/scss'],
-					sourcemaps: true,
-					buildCss: path.basename(buildConfig.demo.sass).replace('.scss', '.css'),
-					buildFolder: dest,
-					cwd: buildConfig.cwd,
-					brand: buildConfig.brand
+	return fileExists(src)
+		.then(exists => {
+			if (!exists) {
+				const e = new Error('Sass file not found: ' + src);
+				e.stack = '';
+				throw e;
+			}
+			return files.getBowerJson(buildConfig.cwd);
+		})
+		.then(bowerConfig => {
+			let prefixSass = '';
+			// If module has o-assets as a dependency, set local demos to use local assets
+			// to use the latest ones in the repo
+			if (bowerConfig && bowerConfig.dependencies && bowerConfig.dependencies['o-assets']) {
+				const moduleName = bowerConfig.name;
+				prefixSass = '@import \'o-assets/main\';\n' +
+					'@include oAssetsSetModulePaths((' + moduleName + ': ""));\n';
+			}
+
+			const sassConfig = {
+				sass: src,
+				sassPrefix: prefixSass,
+				// For the Sass files to load correctly, they need to be in one of these two directories.
+				// Sass doesn't look in subdirectories and we can't use wildcards
+				sassIncludePaths: ['demos/src', 'demos/src/scss'],
+				sourcemaps: true,
+				buildCss: path.basename(buildConfig.demo.sass).replace('.scss', '.css'),
+				buildFolder: dest,
+				cwd: buildConfig.cwd,
+				brand: buildConfig.brand
+			};
+
+			// Only output sass warnings with the verbose flag.
+			if (! buildConfig.verbose) {
+				sassConfig.sassFunctions = {
+					'@warn': function () {
+						return nodeSass.NULL;
+					}
 				};
+			}
 
-				// Only output sass warnings with the verbose flag.
-				if (! buildConfig.verbose) {
-					sassConfig.sassFunctions = {
-						'@warn': function () {
-							return nodeSass.NULL;
-						}
-					};
-				}
-
-				return buildsass(sassConfig);
-			});
-	}
+			return buildsass(sassConfig);
+		});
 }
 
 function buildJs(buildConfig) {
@@ -74,23 +70,19 @@ function buildJs(buildConfig) {
 	const dest = path.basename(buildConfig.demo.js);
 	return fileExists(src)
 		.then(exists => {
-			if (!builtFiles.js.includes(src)) {
-				if (!exists) {
-					const e = new Error('JavaScript file not found: ' + src);
-					e.stack = '';
-					throw e;
-				}
-
-				builtFiles.js.push(src);
-
-				const jsConfig = {
-					js: src,
-					buildFolder: destFolder,
-					buildJs: dest
-				};
-
-				return buildJS(jsConfig);
+			if (!exists) {
+				const e = new Error('JavaScript file not found: ' + src);
+				e.stack = '';
+				throw e;
 			}
+
+			const jsConfig = {
+				js: src,
+				buildFolder: destFolder,
+				buildJs: dest
+			};
+
+			return buildJS(jsConfig);
 		});
 }
 
@@ -355,8 +347,6 @@ module.exports = function (cfg) {
 			}
 
 			const demos = [];
-			builtFiles.css = [];
-			builtFiles.js = [];
 
 			if (!Array.isArray(demosConfig.demos)) {
 				const e = new Error('No demos exist in origami.json file. Reference http://origami.ft.com/docs/syntax/origamijson/ to help configure demos for the component.');
@@ -415,35 +405,66 @@ module.exports = function (cfg) {
 				e.stack = '';
 				throw e;
 			}
-
-			const p = [];
-
+			// Check if obt is watching for Sass changes.
+			const watchingSass = config && (
+				typeof config.watching === 'undefined' ||
+				config.watching === 'sass'
+			);
+			// Check if obt is watching for JavaScript changes.
+			const watchingJs = config && (
+				typeof config.watching === 'undefined' ||
+				config.watching === 'js'
+			);
+			// Create an array of configuration for each demo asset to build.
+			const htmlBuildsConfig = [];
+			const sassBuildsConfig = [];
+			const jsBuildsConfig = [];
+			// Create build configuration for each demo asset if it doesn't
+			// already exist. For example two demos may share the same Sass.
 			for (const demo of demos) {
-
 				const buildConfig = {
-					demo: demo,
+					demo: demo || {},
 					verbose: config.verbose,
 					brand: config.brand,
+					staticSource: config.production ? 'dist' : undefined,
 					cwd: cwd
 				};
-
-				if (config.production) {
-					buildConfig.staticSource = 'dist';
-					p.push(buildHtml(buildConfig));
-				} else {
-					p.push(buildHtml(buildConfig));
-
-					if (demo.sass && (config && (typeof config.watching === 'undefined' || config.watching === 'sass'))) {
-						p.push(buildSass(buildConfig));
+				// Add demo html config.
+				htmlBuildsConfig.push(buildConfig);
+				// Only build Sass and JS if in a development environment.
+				///
+				// At the time of writing the origami-build-service uses the
+				// origami-build-tools demo command to build demo html. When
+				// production is true we do not build CSS/JS so
+				// origami-build-service can return html quickly. It is unlikely
+				// origami-build-tools will be a dependency of the build service
+				// in the future, at which point production checks when building
+				// demos becomes redundant.
+				//
+				// https://github.com/Financial-Times/origami-build-service/blob/3770a76ca3df19abaf99936110e171370b41bce5/lib/democompiler.js#L61
+				if (!config.production) {
+					const newSassBuild = !sassBuildsConfig.find(existingConfig =>
+						existingConfig.demo.sass === buildConfig.demo.sass
+					);
+					if (demo.sass && watchingSass && newSassBuild) {
+						sassBuildsConfig.push(buildConfig);
 					}
 
-					if (demo.js && (config && (typeof config.watching === 'undefined' || config.watching === 'js'))) {
-						p.push(buildJs(buildConfig));
+					const newJsBuild = !jsBuildsConfig.find(existingConfig =>
+						existingConfig.demo.js === buildConfig.demo.js
+					);
+					if (demo.js && watchingJs && newJsBuild) {
+						jsBuildsConfig.push(buildConfig);
 					}
 				}
 			}
 
-			return Promise.all(p);
+			// Return build promises for all demo assets.
+			return Promise.all([
+				...htmlBuildsConfig.map(c => buildHtml(c)),
+				...sassBuildsConfig.map(c => buildSass(c)),
+				...jsBuildsConfig.map(c => buildJs(c))
+			]);
 		}, () => {
 			const configError = 'Couldn\'t find demos config path, checked: ' + configPath;
 			const e = new Error(configError);


### PR DESCRIPTION
Builds are asynchronous, and would previously all start before
the flag which prevents multiple of the same build was set.

o-buttons, which has a lot of demos, builds around ~4.5s instead
of ~36.65s. Making it about ~7.85 times faster! :ta-da: