### PR TITLE
Upgrade mustache.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "merge-stream": "^1.0.1",
     "mocha": "^7.1.1",
     "mockery": "^2.1.0",
-    "mustache": "^2.3.2",
+    "mustache": "^4.0.1",
     "node-sass": "^4.13.1",
     "node.extend": "^2.0.2",
     "npmconf": "^2.1.2",


### PR DESCRIPTION
v2 to v4 does not seems to impact origami-build-tools.

v4: https://github.com/janl/mustache.js/blob/master/CHANGELOG.md#400--16-january-2020 TLDR;
    - if your project manipulates Writer.prototype.parse | Writer.cache directly
    or uses .to_html(), you probably have to change that code.

v3: https://github.com/janl/mustache.js/blob/master/CHANGELOG.md#300--16-september-2018 TLDR;
    - #618: Allow rendering properties of primitive types that are not objects
    - #643: Writer.prototype.parse to cache by tags in addition to template string
    - #664: Fix Writer.prototype.parse cache