### PR TITLE
Remove `babel-plugin-add-module-exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ obt init o-my-new-component
 ### Migrating from 9.X.X to 10.X.X
 
 - NodeJS v10 is no longer supported. Use NodeJS v12 or above.
-
+- A default CommonJs export now maps to `module.exports.default`, the default [Babel](https://babeljs.io/) behaviour. If using `require` to include a default CommonJs export add a `.default` property to the `require` call. Alternatively update your project to use [ECMAScript Module syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
 
 ### Migrating from 8.X.X to 9.X.X
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -48,7 +48,6 @@ module.exports = {
 							],
 							plugins: [
 								[
-									require.resolve('babel-plugin-add-module-exports'),
 									// Polyfills the runtime needed for async/await and generators
 									// Useful for applications rather than components.
 									require.resolve('babel-plugin-transform-runtime'),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "autoprefixer": "^9.7.4",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.5",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es3": "^1.0.1",


### PR DESCRIPTION
All default CommonJS imports will now have a `.default` property.

See: https://github.com/Financial-Times/origami-build-tools/issues/609