### PR TITLE
update deglob to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4763,16 +4763,23 @@
       }
     },
     "deglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
-      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
       "requires": {
         "find-root": "^1.0.0",
         "glob": "^7.0.5",
-        "ignore": "^3.0.9",
+        "ignore": "^5.0.0",
         "pkg-config": "^1.1.0",
         "run-parallel": "^1.1.2",
         "uniq": "^1.0.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+        }
       }
     },
     "del": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chokidar": "^2.1.8",
     "colors": "^1.4.0",
     "cssnano": "^4.1.10",
-    "deglob": "^2.1.0",
+    "deglob": "^4.0.1",
     "elegant-spinner": "^2.0.0",
     "eslint": "^4.9.0",
     "eslint-plugin-import": "^2.20.1",


### PR DESCRIPTION
deglob stopped testing on non-LTS NodeJS versions which is why they increased the major version