### PR TITLE
update karma-scss-preprocessor to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7545,19 +7545,19 @@
       }
     },
     "karma-scss-preprocessor": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/karma-scss-preprocessor/-/karma-scss-preprocessor-3.0.0.tgz",
-      "integrity": "sha1-LecI5Emx/DpxgsWNbGk4Dy+b87Y=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/karma-scss-preprocessor/-/karma-scss-preprocessor-4.0.0.tgz",
+      "integrity": "sha512-dL3SpV67082x2WZQMpUJFIWLIeQwfuqulR16C4G1Hu5ZQBzsY66xYlNEA7QGlX/XHPKCcucCN06mDQ6clSZp1g==",
       "requires": {
-        "chalk": "^2.0.1",
-        "lodash": "^4.17.4",
-        "strip-ansi": "^4.0.0"
+        "chalk": "^2.4.1",
+        "lodash": "^4.17.11",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -7570,11 +7570,11 @@
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "karma-browserstack-launcher": "^1.5.1",
     "karma-chrome-launcher": "^3.1.0",
     "karma-mocha": "^1.3.0",
-    "karma-scss-preprocessor": "^3.0.0",
+    "karma-scss-preprocessor": "^4.0.0",
     "karma-sinon": "^1.0.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.13",


### PR DESCRIPTION
breaking change from karma-scss-prepocesser:

    Upgraded minimum NodeJS version to 6