### PR TITLE
update log-symbols to latest version:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8143,11 +8143,11 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
       },
       "dependencies": {
         "chalk": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.13",
     "listr": "^0.12.0",
-    "log-symbols": "^2.1.0",
+    "log-symbols": "^3.0.0",
     "log-update": "^2.1.0",
     "memory-fs": "^0.4.1",
     "meow": "^6.1.0",


### PR DESCRIPTION
log-symbols breaking changes:

    Require Node.js 8 e1542f5