### PR TITLE
update parse-gitignore to latest version

### DIFF
--- a/lib/tasks/boilerplate.js
+++ b/lib/tasks/boilerplate.js
@@ -10,6 +10,7 @@ const buildTree = (root, name) => {
 	return Promise.all([
 		generate('/.circleci/config.yml', template.ciConfigYml()),
 		generate('/.gitignore', template.gitIgnore()),
+		generate('/.eslintignore', template.eslintIgnore()),
 		generate('/.eslintrc.json', template.eslint()),
 		generate('/bower.json', template.bowerJson(name)),
 		generate('/main.js', template.mainJs(name)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11649,33 +11649,9 @@
       }
     },
     "parse-gitignore": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.4.0.tgz",
-      "integrity": "sha1-q/cC5LkAUk//eQK2g4YoV7Y/k/4=",
-      "requires": {
-        "array-unique": "^0.3.2",
-        "is-glob": "^3.1.0"
-      },
-      "dependencies": {
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-1.0.1.tgz",
+      "integrity": "sha512-UGyowyjtx26n65kdAMWhm6/3uy5uSrpcuH7tt+QEVudiBoVS+eqHxD5kbi9oWVRwj7sCzXqwuM+rUGw7earl6A=="
     },
     "parse-glob": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "node.extend": "^2.0.2",
     "npmconf": "^2.1.2",
     "pa11y": "^5.3.0",
-    "parse-gitignore": "^0.4.0",
+    "parse-gitignore": "^1.0.1",
     "portfinder": "^1.0.25",
     "postcss": "^7.0.27",
     "proclaim": "^3.6.0",

--- a/templates/boilerplate.js
+++ b/templates/boilerplate.js
@@ -7,6 +7,7 @@ module.exports = {
 	demoPa11y: require('./component-boilerplate/demo-pa11y'),
 	demoSass: require('./component-boilerplate/demo-sass'),
 	eslint: require('./component-boilerplate/eslint'),
+	eslintIgnore: require('./component-boilerplate/eslint-ignore'),
 	gitIgnore: require('./component-boilerplate/git-ignore'),
 	mainJs: require('./component-boilerplate/main-js'),
 	mainScss: require('./component-boilerplate/main-scss'),

--- a/templates/component-boilerplate/eslint-ignore.js
+++ b/templates/component-boilerplate/eslint-ignore.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = () => {
+	return `.DS_Store
+.env
+/.sass-cache/
+/bower_components/
+/node_modules/
+/build/
+.idea/
+/demos/local
+/coverage`;
+};


### PR DESCRIPTION
parse-gitignore v1 breaking change is that it no longer attempts to turn ignores into globs.

We never used that behavior though :-)