### PR TITLE
Upgrade merge-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "log-update": "^4.0.0",
     "memory-fs": "^0.4.1",
     "meow": "^6.1.0",
-    "merge-stream": "^1.0.1",
+    "merge-stream": "^2.0.0",
     "mocha": "^7.1.1",
     "mockery": "^2.1.0",
     "mustache": "^4.0.1",


### PR DESCRIPTION
Drops support for node 4 and 0.10.
https://github.com/grncdr/merge-stream/compare/v1.0.1...v2.0.0