### PR TITLE
Remove remote demo data feature.

### DIFF
--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -8,7 +8,6 @@ const buildJs = require('../tasks/build-js');
 const buildSass = require('../tasks/build-sass');
 const mustache = require('mustache');
 const denodeify = require('util').promisify;
-const axios = require('axios');
 
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
@@ -77,49 +76,6 @@ function buildDemoJs(buildConfig) {
 		});
 }
 
-/**
- * @param {String} url - the url to get demo data from
- * @return {Promise} - resolves to demo data
- */
-function loadRemoteDemoData(url) {
-	const genericErrorMessage = 'Could not load remote demo data.';
-	// Check if the url given is valid, error if not.
-	try {
-		new URL(url);
-	} catch (e) {
-		const error = new Error(
-			`${genericErrorMessage} ${url} does not appear to be valid.`
-		);
-		error.stack = '';
-		return Promise.reject(error);
-	}
-
-	// Get json from the given url.
-	return axios.get(url)
-		.then(response => {
-			// Return if json data found.
-			if (typeof response.data === 'object') {
-				return response.data;
-			}
-			// Error if response does not contain valid json.
-			const error = new Error(
-				`${genericErrorMessage} ${url} did not provide valid JSON.`
-			);
-			error.stack = '';
-			throw error;
-		})
-		.catch((error) => {
-			// Put status code in error message if we have a response.
-			if (error.response) {
-				error.message = `${genericErrorMessage} ` +
-					`${url} returned a ${error.response.status} status code.`;
-				error.stack = '';
-			}
-			// Otherwise forward any unknown errors.
-			throw error;
-		});
-}
-
 function loadLocalDemoData(dataPath) {
 	return readFile(dataPath, 'utf-8')
 		.then(file => {
@@ -145,13 +101,8 @@ function loadLocalDemoData(dataPath) {
 
 function loadDemoData(buildConfig) {
 	if (typeof buildConfig.demo.data === 'string') {
-		const dataPathIsRemote = /^(?:https?:)\/\//.test(buildConfig.demo.data);
-		const dataPath = dataPathIsRemote ? buildConfig.demo.data : path.join(buildConfig.cwd, '/' + buildConfig.demo.data);
-		if (dataPathIsRemote) {
-			return loadRemoteDemoData(dataPath);
-		} else {
-			return loadLocalDemoData(dataPath);
-		}
+		const dataPath = path.join(buildConfig.cwd, '/' + buildConfig.demo.data);
+		return loadLocalDemoData(dataPath);
 	} else if (typeof buildConfig.demo.data === 'object') {
 		return Promise.resolve(buildConfig.demo.data);
 	} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2154,32 +2154,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.2.tgz",
       "integrity": "sha512-9wBDgdzbn06on6Xt+ay7EM4HV+NBOkeXhjK9DMezD8/qvJKeUTzheGHhM+U1uNaX4OvuIR4BePDStRLF7vyOfg=="
     },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        }
-      }
-    },
     "babel-loader": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "aliases": "^1.0.0",
     "app-root-path": "^3.0.0",
     "autoprefixer": "^9.7.4",
-    "axios": "^0.19.2",
     "babel-loader": "^8.1.0",
     "bower": "^1.8.8",
     "bower-resolve-webpack-plugin": "^1.0.5",

--- a/test/unit/tasks/demo-build.test.js
+++ b/test/unit/tasks/demo-build.test.js
@@ -102,7 +102,7 @@ describe('Demo task', function () {
 				"path": "/demos/test2.html",
 				"hidden": true,
 				"description": "Second test"
-			});
+			}]);
 			fs.writeFileSync('demos/src/test1.mustache', '<div>test1</div>', 'utf8');
 			fs.writeFileSync('demos/src/test2.mustache', '<div>test2</div>', 'utf8');
 			return demo({

--- a/test/unit/tasks/demo-build.test.js
+++ b/test/unit/tasks/demo-build.test.js
@@ -12,14 +12,11 @@ const oTestPath = 'test/unit/fixtures/o-test';
 const oNoManifestPath = path.resolve(obtPath, 'test/unit/fixtures/o-no-manifest');
 const pathSuffix = '-demo';
 const demoTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
-const axios = require('axios');
 const demo = require('../../../lib/tasks/demo-build');
 
 describe('Demo task', function () {
-	let axiosStub;
 
 	beforeEach(function () {
-		axiosStub = sinon.stub(axios, 'get');
 		fs.copySync(path.resolve(obtPath, oTestPath), demoTestPath);
 		process.chdir(demoTestPath);
 		mockery.enable({
@@ -94,14 +91,6 @@ describe('Demo task', function () {
 		});
 
 		it('should build demo html', function () {
-			const demoDataLabel = 'Footer';
-			axiosStub.callsFake(() => Promise.resolve({
-				data: {
-					"label": demoDataLabel,
-					"items": []
-				}
-			}));
-
 			addDemoToOrigamiConfig([{
 				"name": "test1",
 				"template": "demos/src/test1.mustache",
@@ -113,16 +102,9 @@ describe('Demo task', function () {
 				"path": "/demos/test2.html",
 				"hidden": true,
 				"description": "Second test"
-			}, {
-				"name": "remote-data",
-				"template": "demos/src/remote-data.mustache",
-				"path": "/demos/remote-data.html",
-				"description": "Third test",
-				"data": "http://origami.ft.com/#stubedRequest1"
-			}]);
+			});
 			fs.writeFileSync('demos/src/test1.mustache', '<div>test1</div>', 'utf8');
 			fs.writeFileSync('demos/src/test2.mustache', '<div>test2</div>', 'utf8');
-			fs.writeFileSync('demos/src/remote-data.mustache', '<div>{{{label}}}</div>', 'utf8');
 			return demo({
 				production: true
 			}).then(function () {
@@ -132,9 +114,6 @@ describe('Demo task', function () {
 				const test2 = fs.readFileSync('demos/test2.html', 'utf8');
 				proclaim.include(test2, '<div>test2</div>');
 				proclaim.match(test2, /\/v3\/polyfill\.min\.js\?features=.*promises/);
-				const testRemoteData = fs.readFileSync('demos/remote-data.html', 'utf8');
-				proclaim.include(testRemoteData, `<div>${demoDataLabel}</div>`);
-				proclaim.match(testRemoteData, /\/v3\/polyfill\.min\.js\?features=.*promises/);
 			});
 		});
 
@@ -211,108 +190,6 @@ describe('Demo task', function () {
 				});
 		});
 
-		it('should fail if a remote url does not return valid json', function () {
-			// Stub for invalid json.
-			axiosStub.callsFake(() => Promise.resolve({
-				data: `{
-					"label": none valid json,
-					"items": []}}}
-				}`
-			}));
-			// Create demo config.
-			const remoteDataUrl = 'http://origami.ft.com/#stubedRequest2';
-			fs.writeFileSync('demos/src/remote-data.mustache', '<div>{{{label}}}</div>', 'utf8');
-			addDemoToOrigamiConfig({
-				"name": "remote-data",
-				"template": "demos/src/remote-data.mustache",
-				"path": "/demos/remote-data.html",
-				"description": "Invalid remote data test",
-				"data": remoteDataUrl
-			});
-			// Run invalid json test.
-			return demo({
-				production: true
-			}).then(function () {
-				throw new Error('promise resolved when it should have rejected');
-			}).catch(function (err) {
-				proclaim.equal(err.message, `Could not load remote demo data. ${remoteDataUrl} did not provide valid JSON.`);
-				proclaim.equal(err.stack, '');
-			});
-		});
-
-		it('should fail if a remote url is invalid', function () {
-			// Create invalid demo data config.
-			const remoteDataUrl = 'https://!@£$%^&*()';
-			addDemoToOrigamiConfig({
-				"name": "remote-data",
-				"template": "demos/src/remote-data.mustache",
-				"path": "/demos/remote-data.html",
-				"description": "Invalid url",
-				"data": remoteDataUrl
-			});
-			// Run remote url test.
-			return demo({
-				production: true
-			}).then(function () {
-				throw new Error('promise resolved when it should have rejected');
-			}).catch(function (err) {
-				proclaim.equal(err.message, `Could not load remote demo data. ${remoteDataUrl} does not appear to be valid.`);
-				proclaim.equal(err.stack, '');
-			});
-		});
-
-		it('should show a helpful error message for http status code errors', function () {
-			// Stub for axios error
-			const mockAxiosError = {
-				response: { status: 500 }
-			};
-			axiosStub.callsFake(() => Promise.reject(mockAxiosError));
-
-			// Create demo config.
-			const remoteDataUrl = 'http://origami.ft.com/#stubedRequest3';
-			addDemoToOrigamiConfig({
-				"name": "remote-data",
-				"template": "demos/src/remote-data.mustache",
-				"path": "/demos/remote-data.html",
-				"description": "Remote data url http error.",
-				"data": remoteDataUrl
-			});
-			// Run error HTTP status code test.
-			return demo({
-				production: true
-			}).then(function () {
-				throw new Error('promise resolved when it should have rejected');
-			}).catch(function (err) {
-				proclaim.equal(err.message, `Could not load remote demo data. ${remoteDataUrl} returned a ${mockAxiosError.response.status} status code.`);
-				proclaim.equal(err.stack, '');
-			});
-		});
-
-		it('should show a stack trace if remote demo data retrieval fails for an unknown reason', function () {
-			// Stub for unknown error
-			const mockHttpError = new Error('Mock Unknown Error');
-			mockHttpError.name = 'UnknownError';
-			axiosStub.callsFake(() => Promise.reject(mockHttpError));
-
-			// Create demo config.
-			const remoteDataUrl = 'http://origami.ft.com/#stubedRequest4';
-			addDemoToOrigamiConfig({
-				"name": "remote-data",
-				"template": "demos/src/remote-data.mustache",
-				"path": "/demos/remote-data.html",
-				"description": "Remote data url unknown error.",
-				"data": remoteDataUrl
-			});
-			// Test for a stack trace.
-			return demo({
-				production: true
-			}).then(function () {
-				throw new Error('promise resolved when it should have rejected');
-			}).catch(function (err) {
-				proclaim.notEqual(err.stack, '');
-			});
-		});
-
 		it('should throw an error if local demo data cannot be found', function () {
 			fs.writeFileSync('demos/src/local-data.mustache', '<div>{{{label}}}</div>', 'utf8');
 			const demoDataUri = 'demos/src/does-not-exist-data.mustache';
@@ -321,7 +198,7 @@ describe('Demo task', function () {
 				"name": "local-data",
 				"template": "demos/src/local-data.mustache",
 				"path": "/demos/local-data.html",
-				"description": "Remote data url unknown error.",
+				"description": "local data missing.",
 				"data": demoDataUri
 			});
 


### PR DESCRIPTION
- Our components do not use remote demo data.
- o-header could use this feature to show up-to-date links from
the Navigation Service, but if users copy/paste their navigation
will become out of date. Instead we should use dummy data
(https://github.com/Financial-Times/o-header/issues/160)
- The Origami specification says "if [the demo field] is a string
it must be a path to a JSON file containing the data, relative to
the root of the repo." So remote data is not allowed by the spec.

(Let's not worry about the effort I went to in a previous commit,
to replace `request-promise-native` with `node-fetch`.)