### PR TITLE
use karma-proclaim to make proclaim a global variable used in tests

### DIFF
--- a/config/karma.config.js
+++ b/config/karma.config.js
@@ -50,11 +50,12 @@ module.exports.getBaseKarmaConfig = function (opts = { ignoreBower: false }) {
 
 			// frameworks to use
 			// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-			frameworks: ['mocha', 'sinon'],
+			frameworks: ['mocha', 'sinon', 'proclaim'],
 
 			plugins: [
 				'karma-mocha',
 				'karma-sinon',
+				'karma-proclaim',
 				'karma-webpack',
 				'karma-browserstack-launcher',
 				'karma-chrome-launcher',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7143,6 +7143,13 @@
         }
       }
     },
+    "karma-proclaim": {
+      "version": "git+https://github.com/Financial-Times/karma-proclaim.git#e346e1f4f0519caa0cbcb34660a7a65a876b05ac",
+      "from": "git+https://github.com/Financial-Times/karma-proclaim.git",
+      "requires": {
+        "proclaim": "^3.6.0"
+      }
+    },
     "karma-scss-preprocessor": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/karma-scss-preprocessor/-/karma-scss-preprocessor-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "karma-browserstack-launcher": "^1.5.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
+    "karma-proclaim": "git+https://github.com/Financial-Times/karma-proclaim.git",
     "karma-scss-preprocessor": "^3.0.0",
     "karma-sinon": "^1.0.5",
     "karma-sourcemap-loader": "^0.3.7",


### PR DESCRIPTION
instead of abusing webpack to make proclaim available via import/require.

https://github.com/Financial-Times/origami-build-tools/blob/cf219aa5029754feb0f98c63db87f2af4a439786/config/webpack.config.dev.js#L6-L9