### PR TITLE
Always output Sass debug messages with the verbose flag.

### DIFF
--- a/lib/tasks/build-sass.js
+++ b/lib/tasks/build-sass.js
@@ -95,7 +95,7 @@ module.exports = function buildSass(config) {
 						result = execa.sync(ftSass, sassArguments, { input: sassData });
 						// Output Sass debug logs and warnings
 						if (result.stderr) {
-							log.debug(result.stderr);
+							log.secondary(result.stderr);
 						}
 					} catch (error) {
 						const stderr = error.stderr || '';

--- a/test/unit/tasks/build-sass.test.js
+++ b/test/unit/tasks/build-sass.test.js
@@ -110,7 +110,7 @@ describe('Build Sass', function () {
 		const warningMessage = `This is a warning!`;
 		const debugSass = `@debug "${debugMessage};";`;
 		const warningSass = `@warn "${warningMessage};";`;
-		const logSpy = sinon.spy(log, 'debug');
+		const logSpy = sinon.spy(log, 'secondary');
 		return build({
 			buildCss: 'bundle.css',
 			sassPrefix: debugSass + warningSass,
@@ -128,7 +128,7 @@ describe('Build Sass', function () {
 		const warningMessage = `This is a warning!`;
 		const debugSass = `@debug "${debugMessage};";`;
 		const warningSass = `@warn "${warningMessage};";`;
-		const logSpy = sinon.spy(log, 'debug');
+		const logSpy = sinon.spy(log, 'secondary');
 		return build({
 			buildCss: 'bundle.css',
 			sassPrefix: debugSass + warningSass,


### PR DESCRIPTION
We were using our `log.debug` method to output Sass debug and
warning messages, which is only logged when the enviroment variable
`OBT_LOG_LEVEL` is set to `debug`. We are not debugging the build
tools themselves and so should use the `log.secondary` method
instead.