### PR TITLE
Pass --ignore-bower flag from command line to demo-build

### DIFF
--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -420,7 +420,8 @@ module.exports = function (cfg) {
 					verbose: config.verbose,
 					brand: config.brand,
 					staticSource: config.production ? 'dist' : undefined,
-					cwd: cwd
+					cwd: cwd,
+					ignoreBower: config.ignoreBower
 				};
 				// Add demo html config.
 				htmlBuildsConfig.push(buildConfig);


### PR DESCRIPTION
Missed this bit in https://github.com/Financial-Times/origami-build-tools/pull/738