### PR TITLE
Remove flags we no longer want to support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		-h, --help                 Print out this message
 		--watch                    Re-run every time a file changes
 		--run-server               Build demos locally and runs a server
-		--js=<path>                Main JavaScript file (default: ./src/main.js)
 		--sass=<path>              Main Sass file (default: ./src/main.scss)
 		--build-js=<file>          Compiled JavaScript file (default: main.js)
 		--build-css=<file>         Compiled CSS file (default: main.css)
@@ -72,7 +71,6 @@ It comes with support for things like:
 * [Babel](https://github.com/babel/babel) so you can use ES2017 features in your modules and products
 * [autoprefixer](https://github.com/postcss/autoprefixer) so you don't have to worry about writing browser prefixes in your Sass
 
-Set the main JavaScript file with the `--js` option. _(default: ./src/main.js)_
 Set the main Sass file with the `--sass` option. _(default: ./src/main.scss)_
 Set the name of the built JS file with the `--build-js` option. _(default: main.js)_
 Set the name of the built CSS file with the `--build-css` option. _(default: main.css)_
@@ -121,6 +119,7 @@ obt init o-my-new-component
 
 - NodeJS v10 is no longer supported. Use NodeJS v12 or above.
 - A default CommonJs export now maps to `module.exports.default`, the default [Babel](https://babeljs.io/) behaviour. If using `require` to include a default CommonJs export add a `.default` property to the `require` call. Alternatively update your project to use [ECMAScript Module syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+- Removed the `--js` flag.
 
 ### Migrating from 8.X.X to 9.X.X
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		-h, --help                 Print out this message
 		--watch                    Re-run every time a file changes
 		--run-server               Build demos locally and runs a server
-		--build-js=<file>          Compiled JavaScript file (default: main.js)
 		--build-css=<file>         Compiled CSS file (default: main.css)
 		--build-folder=<dir>       Compiled assets directory (default: ./build/)
 		-v, --version              Print out version of origami-build-tools
@@ -70,7 +69,6 @@ It comes with support for things like:
 * [Babel](https://github.com/babel/babel) so you can use ES2017 features in your modules and products
 * [autoprefixer](https://github.com/postcss/autoprefixer) so you don't have to worry about writing browser prefixes in your Sass
 
-Set the name of the built JS file with the `--build-js` option. _(default: main.js)_
 Set the name of the built CSS file with the `--build-css` option. _(default: main.css)_
 Set the name of the folder to store the built CSS and JS with the `--build-folder` option. _(default: ./build/)_
 
@@ -119,6 +117,7 @@ obt init o-my-new-component
 - A default CommonJs export now maps to `module.exports.default`, the default [Babel](https://babeljs.io/) behaviour. If using `require` to include a default CommonJs export add a `.default` property to the `require` call. Alternatively update your project to use [ECMAScript Module syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
 - Removed the `--js` flag.
 - Removed the `--sass` flag.
+- Removed the `--build-js` flag.
 
 ### Migrating from 8.X.X to 9.X.X
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		--run-server               Build demos locally and runs a server
 		-v, --version              Print out version of origami-build-tools
 		--browserstack             Run tests using Browserstack instead of Chrome Stable
-		--standalone               Create a named export for the built JavaScript
 		--demo-filter=<demo-name>  Build a specific demo. E.G. --demo-filter=pa11y to build only the pa11y.html demo.
 		--brand=<brand-name>       Build SCSS for a given brand. E.G. --brand=internal to build the component for the internal brand.
 		--suppress-errors          Do not error if no demos are found when using the --demo-filter option.
@@ -118,6 +117,7 @@ obt init o-my-new-component
 - Removed the `--build-js` flag.
 - Removed the `--build-css` flag.
 - Removed the `--build-folder` flag.
+- Removed the `--standalone` flag.
 
 
 ### Migrating from 8.X.X to 9.X.X

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		-h, --help                 Print out this message
 		--watch                    Re-run every time a file changes
 		--run-server               Build demos locally and runs a server
-		--sass=<path>              Main Sass file (default: ./src/main.scss)
 		--build-js=<file>          Compiled JavaScript file (default: main.js)
 		--build-css=<file>         Compiled CSS file (default: main.css)
 		--build-folder=<dir>       Compiled assets directory (default: ./build/)
@@ -71,7 +70,6 @@ It comes with support for things like:
 * [Babel](https://github.com/babel/babel) so you can use ES2017 features in your modules and products
 * [autoprefixer](https://github.com/postcss/autoprefixer) so you don't have to worry about writing browser prefixes in your Sass
 
-Set the main Sass file with the `--sass` option. _(default: ./src/main.scss)_
 Set the name of the built JS file with the `--build-js` option. _(default: main.js)_
 Set the name of the built CSS file with the `--build-css` option. _(default: main.css)_
 Set the name of the folder to store the built CSS and JS with the `--build-folder` option. _(default: ./build/)_
@@ -120,6 +118,7 @@ obt init o-my-new-component
 - NodeJS v10 is no longer supported. Use NodeJS v12 or above.
 - A default CommonJs export now maps to `module.exports.default`, the default [Babel](https://babeljs.io/) behaviour. If using `require` to include a default CommonJs export add a `.default` property to the `require` call. Alternatively update your project to use [ECMAScript Module syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
 - Removed the `--js` flag.
+- Removed the `--sass` flag.
 
 ### Migrating from 8.X.X to 9.X.X
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		-h, --help                 Print out this message
 		--watch                    Re-run every time a file changes
 		--run-server               Build demos locally and runs a server
-		--build-folder=<dir>       Compiled assets directory (default: ./build/)
 		-v, --version              Print out version of origami-build-tools
 		--browserstack             Run tests using Browserstack instead of Chrome Stable
 		--standalone               Create a named export for the built JavaScript
@@ -118,6 +117,8 @@ obt init o-my-new-component
 - Removed the `--sass` flag.
 - Removed the `--build-js` flag.
 - Removed the `--build-css` flag.
+- Removed the `--build-folder` flag.
+
 
 ### Migrating from 8.X.X to 9.X.X
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		-h, --help                 Print out this message
 		--watch                    Re-run every time a file changes
 		--run-server               Build demos locally and runs a server
-		--build-css=<file>         Compiled CSS file (default: main.css)
 		--build-folder=<dir>       Compiled assets directory (default: ./build/)
 		-v, --version              Print out version of origami-build-tools
 		--browserstack             Run tests using Browserstack instead of Chrome Stable
@@ -118,6 +117,7 @@ obt init o-my-new-component
 - Removed the `--js` flag.
 - Removed the `--sass` flag.
 - Removed the `--build-js` flag.
+- Removed the `--build-css` flag.
 
 ### Migrating from 8.X.X to 9.X.X
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		--brand=<brand-name>       Build SCSS for a given brand. E.G. --brand=internal to build the component for the internal brand.
 		--suppress-errors          Do not error if no demos are found when using the --demo-filter option.
 		--debug                    Keep the test runner open to enable debugging in any browser.
-		--verbose                  Output sass warnings with backtraces.
 
 ### Developing modules locally
 
@@ -118,6 +117,7 @@ obt init o-my-new-component
 - Removed the `--build-css` flag.
 - Removed the `--build-folder` flag.
 - Removed the `--standalone` flag.
+- Removed the `--verbose` flag.
 
 
 ### Migrating from 8.X.X to 9.X.X

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -36,7 +36,6 @@ const help = `
 			--watch                    Re-run every time a file changes
 			--run-server               Build demos locally and runs a server
 			--port=<port>              The port to run the local server on if available (default: 8999).
-			--build-folder=<dir>       Compiled assets directory (default: ./build/)
 			-v, --version              Print out version of origami-build-tools
 			--ignore-bower             Ignore files related to the bower package manager
 			--browserstack             Run tests using Browserstack instead of Chrome Stable. Requires BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY to be set.
@@ -170,7 +169,7 @@ if (task && cli.flags.watch) {
 	chokidar.watch(cli.flags.cwd || process.cwd(), {
 		ignored: [
 			'node_modules',
-			cli.flags.buildFolder || 'build',
+			'build',
 			'.git',
 			'bower_components',
 			'demos/local'

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -36,7 +36,6 @@ const help = `
 			--watch                    Re-run every time a file changes
 			--run-server               Build demos locally and runs a server
 			--port=<port>              The port to run the local server on if available (default: 8999).
-			--build-css=<file>         Compiled CSS file (default: main.css)
 			--build-folder=<dir>       Compiled assets directory (default: ./build/)
 			-v, --version              Print out version of origami-build-tools
 			--ignore-bower             Ignore files related to the bower package manager

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -39,7 +39,6 @@ const help = `
 			-v, --version              Print out version of origami-build-tools
 			--ignore-bower             Ignore files related to the bower package manager
 			--browserstack             Run tests using Browserstack instead of Chrome Stable. Requires BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY to be set.
-			--standalone               Create a named export for the built JavaScript
 			--demo-filter=<demo-name>  Build a specific demo. E.G. --demo-filter=pa11y to build only the pa11y.html demo.
 			--suppress-errors          Do not error if no demos are found when using the --demo-filter option.
 			--debug                    Keep the test runner open to enable debugging in any browser.

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -36,7 +36,6 @@ const help = `
 			--watch                    Re-run every time a file changes
 			--run-server               Build demos locally and runs a server
 			--port=<port>              The port to run the local server on if available (default: 8999).
-			--build-js=<file>          Compiled JavaScript file (default: main.js)
 			--build-css=<file>         Compiled CSS file (default: main.css)
 			--build-folder=<dir>       Compiled assets directory (default: ./build/)
 			-v, --version              Print out version of origami-build-tools

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -42,7 +42,6 @@ const help = `
 			--demo-filter=<demo-name>  Build a specific demo. E.G. --demo-filter=pa11y to build only the pa11y.html demo.
 			--suppress-errors          Do not error if no demos are found when using the --demo-filter option.
 			--debug                    Keep the test runner open to enable debugging in any browser.
-			--verbose                  Output sass warnings with backtraces.
 
 		Full documentation
 			http://git.io/bBjMNw

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -36,7 +36,6 @@ const help = `
 			--watch                    Re-run every time a file changes
 			--run-server               Build demos locally and runs a server
 			--port=<port>              The port to run the local server on if available (default: 8999).
-			--js=<path>                Main JavaScript file (default: ./src/main.js)
 			--sass=<path>              Main Sass file (default: ./src/main.scss)
 			--build-js=<file>          Compiled JavaScript file (default: main.js)
 			--build-css=<file>         Compiled CSS file (default: main.css)

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -36,7 +36,6 @@ const help = `
 			--watch                    Re-run every time a file changes
 			--run-server               Build demos locally and runs a server
 			--port=<port>              The port to run the local server on if available (default: 8999).
-			--sass=<path>              Main Sass file (default: ./src/main.scss)
 			--build-js=<file>          Compiled JavaScript file (default: main.js)
 			--build-css=<file>         Compiled CSS file (default: main.css)
 			--build-folder=<dir>       Compiled assets directory (default: ./build/)

--- a/lib/tasks/build-sass.js
+++ b/lib/tasks/build-sass.js
@@ -46,7 +46,7 @@ function getSassData(sassFile, config = {
  * @param {String|Undefined} config.brand [undefined] - The brand the Sass build is for .e.g. "master", "internal", or "whitelabel".
  * @param {String|Undefined} config.sassPrefix [undefined] - Sass to prefix the Sass from file with.
  * @param {String} config.outputStyle ['expanded'] - The Sass output style. One of `compressed` (removes as many extra characters as possible) or `expanded` (writes each selector and declaration on its own line).
- * @param {Boolean} config.verbose [false] - When true, Sass warnings and debug messages are output.
+ * @param {Boolean} config.verbose [true] - When true, Sass warnings and debug messages are output.
  * @param {String[]} config.sassIncludePaths - Extra Sass paths to includes.
  * @param {Boolean} config.ignoreBower - True to include npm Sass paths, otherwise bower paths are used.
  * @return {String} - The built css.
@@ -65,6 +65,7 @@ module.exports = function buildSass(config) {
 				brand: config.brand,
 				sassPrefix: config.sassPrefix,
 			});
+			const verbose = 'verbose' in config ? config.verbose : true;
 
 			return Promise.resolve(sassData)
 				.then(sassData => {
@@ -84,7 +85,7 @@ module.exports = function buildSass(config) {
 						['--no-source-map'],
 					);
 					// Only emit warnings or debug notices when in verbose mode
-					if (!config.verbose) {
+					if (!verbose) {
 						sassArguments.push('--quiet');
 					}
 					// Build Sass


### PR DESCRIPTION
This is part of the work for https://github.com/Financial-Times/origami-build-tools/issues/735

- Removed the `--js` flag.
- Removed the `--sass` flag.
- Removed the `--build-js` flag.
- Removed the `--build-css` flag.
- Removed the `--build-folder` flag.
- Removed the `--standalone` flag.
- Removed the `--verbose` flag.