### PR TITLE
Add new `develop` command. Remove `watch` and `run-server` flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,33 @@ Runs tests using [Karma](https://karma-runner.github.io) defaulting to Chrome St
 
 ### Migrating from 9.X.X to 10.X.X
 
-- NodeJS v10 is no longer supported. Use NodeJS v12 or above.
-- A default CommonJs export now maps to `module.exports.default`, the default [Babel](https://babeljs.io/) behaviour. If using `require` to include a default CommonJs export add a `.default` property to the `require` call. Alternatively update your project to use [ECMAScript Module syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+The following `demo` command flags have been removed and replaced with the `develop` (`dev`) command:
+- Removed the `--watch` flag.
+- Removed the `--run-server` flag.
+
+```diff
+-obt demo --watch --run-server
++obt dev
+```
+
+JavaScript and Sass is compiled to the [recommended directory structure](https://origami.ft.com/spec/v1/components/#files-and-folder-structure). The flags to customise this have been removed from origami-build-tools:
 - Removed the `--js` flag.
 - Removed the `--sass` flag.
 - Removed the `--build-js` flag.
 - Removed the `--build-css` flag.
 - Removed the `--build-folder` flag.
-- Removed the `--standalone` flag.
+
+All logs are now output from Sass compilation by default. The `verbose` flag has been removed:
 - Removed the `--verbose` flag.
-- The `--suppress-errors` flag has been removed. OBT no longer throws an error if their are no demos to be built if passed the `--demo-filter` flag.
-- v10 replaces the deprecated [scss-lint](https://github.com/sasstools/sass-lint) with [stylelint](https://github.com/stylelint/stylelint). Your component may fail the verify check and require Sass updates, including:
+
+In addition, the following flags have been removed:
+- `--standalone`. It is no longer possible to specify a named export for the built JavaScript
+- `--suppress-errors`. OBT no longer throws an error if their are no demos to be built if passed the `--demo-filter` flag.
+
+Other changes include:
+- NodeJS v10 is no longer supported. Use NodeJS v12 or above.
+- A default CommonJs export now maps to `module.exports.default`, the default [Babel](https://babeljs.io/) behaviour. If using `require` to include a default CommonJs export add a `.default` property to the `require` call. Alternatively update your project to use [ECMAScript Module syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+- The deprecated [scss-lint](https://github.com/sasstools/sass-lint) package has been replaced with [stylelint](https://github.com/stylelint/stylelint). Your component may fail the verify check and require Sass updates, including:
 	- If your component uses Sass comments to temporarily disable linting (e.g. `// sass-lint:disable`) replace these with the [equivalent stylelint-disable comment for stylelint](https://stylelint.io/user-guide/ignore-code).
 	- Components by default must be indented with tabs, unless configured otherwise.
 	- Empty blocks will now error `.nothing-here {}`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 
 2. Install the build tools globally:
 
-		npm install -g origami-build-tools
+	`npm install -g origami-build-tools`
 
 ## Usage
 
@@ -25,29 +25,28 @@ If you have any issues with OBT, please check out [troubleshooting guide](https:
 		$ obt <command> [<options>]
 
 	Commands
-		build, b    Build CSS and JS in current directory
-		demo, d     Build demos into the demos directory
-		init        Initialise a new component with a boilerplate folder structure
-		install, i  Install npm and bower dependencies required to build modules
-		test, t     Run Origami specification tests and component specific tests
-		verify, v   Check folder and code structure follows Origami specification
+		develop, dev  Build demos locally every time a file changes and run a server to view them.
+		build, b      Build CSS and JS in current directory
+		demo, d       Build demos into the demos directory
+		init          Initialise a new component with a boilerplate folder structure
+		install, i    Install npm and bower dependencies required to build modules
+		test, t       Run Origami specification tests and component specific tests
+		verify, v     Check folder and code structure follows Origami specification
 
 	Options
 		-h, --help                 Print out this message
-		--watch                    Re-run every time a file changes
-		--run-server               Build demos locally and runs a server
 		-v, --version              Print out version of origami-build-tools
 		--browserstack             Run tests using Browserstack instead of Chrome Stable
 		--demo-filter=<demo-name>  Build a specific demo. E.G. --demo-filter=pa11y to build only the pa11y.html demo.
 		--brand=<brand-name>       Build SCSS for a given brand. E.G. --brand=internal to build the component for the internal brand.
 		--debug                    Keep the test runner open to enable debugging in any browser.
 
-### Developing modules locally
+### Developing components locally
 
 Build and browse the demos (typically: <http://localhost:8080/demos/local/>),
-automatically re-build the module's demos and assets every time a file changes:
+automatically re-build the component's demos and assets every time a file changes:
 
-	origami-build-tools demo --runServer --watch
+	`obt dev`
 
 ## Commands
 
@@ -55,22 +54,21 @@ automatically re-build the module's demos and assets every time a file changes:
 
 Install npm and bower dependencies required to build modules.
 
+### `develop` or `dev`
+
+Build demos locally every time a file changes and run a server to view them.
+
+### `init`
+
+Creates boilerplate for a new Origami component.
+
 ### `build` or `b`
 
-Build CSS and JavaScript bundles (typically, from `main.js` and `main.css`).
-
-It comes with support for things like:
-
-* [Babel](https://github.com/babel/babel) so you can use ES2017 features in your modules and products
-* [autoprefixer](https://github.com/postcss/autoprefixer) so you don't have to worry about writing browser prefixes in your Sass
-
-Set the name of the built CSS file with the `--build-css` option. _(default: main.css)_
-Set the name of the folder to store the built CSS and JS with the `--build-folder` option. _(default: ./build/)_
-
+Build CSS and JavaScript bundles from `main.js` and `main.css`.
 
 ### `demo` or `d`
 
-Build demos found in the [demo config file](http://origami.ft.com/docs/component-spec/modules/#demo-config).
+Build demos found in the [origami.json manifest](https://origami.ft.com/spec/v1/manifest/#demos).
 
 Build a specific demo with the `--demo-filter` option.
 
@@ -78,11 +76,11 @@ Demos consist of HTML, CSS and JS (if Sass & JS exists), and are created in `dem
 
 ### `verify` or `v`
 
-Lints JavaScript, Sass and configuration files against [Origami coding standards](http://origami.ft.com/docs/syntax/).
+Lints JavaScript, Sass and configuration files against [Origami specification](https://origami.ft.com/spec/v1/components/).
 
 ### `test` or `t`
 
-Run Origami specification tests and component specific tests.
+Runs JavaScript and Sass tests.
 
 * If `--debug` is set, the test runner will not exit automatically to allow debugging of the tests.
 
@@ -90,18 +88,6 @@ Checks Sass supports [silent and non-silent compilation modes](http://origami.ft
 If `pa11y.html` demo exists, confirms it is accessible using [Pa11y](http://pa11y.org/).
 If `package.json` contains a `test` script, confirms it exits with a 0 exit code.
 Runs tests using [Karma](https://karma-runner.github.io) defaulting to Chrome Stable, can be configured to use BrowserStack by using the `--browserstack` flag. You will need the environment variables `BROWSER_STACK_USERNAME` and `BROWSER_STACK_ACCESS_KEY` set. This will run the tests on the minimum version for enhanced experience based on the [FT Browser Support Policy[(https://docs.google.com/document/d/1mByh6sT8zI4XRyPKqWVsC2jUfXHZvhshS5SlHErWjXU).
-
-
-### `init`
-
-Initialises a new component with a full boilerplate folder structure.
-
-This command takes an argument in the form of a component name, which will populate all of the relevant files within that tree. Defaults to `o-component-boilerplate`.
-
-e.g.
-```
-obt init o-my-new-component
-```
 
 ## Migration guide
 

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -13,6 +13,7 @@ const os = require('os');
 const path = require('path');
 const portfinder = require('portfinder');
 const boxen = require('boxen');
+const log = require('./helpers/log');
 
 const rootCheck = require('root-check');
 rootCheck(`You are not allowed to run this app with root permissions.
@@ -24,23 +25,21 @@ const help = `
 			$ obt <command> [<options>]
 
 		Commands
-			build, b    Build CSS and JS in current directory
-			demo, d     Build demos into the demos directory
-			init        Initialise a new component with a boilerplate folder structure
-			install, i  Install npm and bower dependencies required to build modules
-			test, t     Run Origami specification tests and component specific tests
-			verify, v   Check folder and code structure follows Origami specification
+			develop, dev  Build demos locally every time a file changes and run a server to view them.
+			build, b      Build CSS and JS in current directory
+			demo, d       Build demos into the demos directory
+			init          Initialise a new component with a boilerplate folder structure
+			install, i    Install npm and bower dependencies required to build modules
+			test, t       Run Origami specification tests and component specific tests
+			verify, v     Check folder and code structure follows Origami specification
 
 		Options
 			-h, --help                 Print out this message
-			--watch                    Re-run every time a file changes
-			--run-server               Build demos locally and runs a server
 			--port=<port>              The port to run the local server on if available (default: 8999).
 			-v, --version              Print out version of origami-build-tools
 			--ignore-bower             Ignore files related to the bower package manager
 			--browserstack             Run tests using Browserstack instead of Chrome Stable. Requires BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY to be set.
 			--demo-filter=<demo-name>  Build a specific demo. E.G. --demo-filter=pa11y to build only the pa11y.html demo.
-			--suppress-errors          Do not error if no demos are found when using the --demo-filter option.
 			--debug                    Keep the test runner open to enable debugging in any browser.
 
 		Full documentation
@@ -125,11 +124,6 @@ async function startServer(port, previous) {
 
 let server;
 
-if (cli.flags.runServer) {
-	const port = cli.flags.port || 8999;
-	startServer(port);
-}
-
 const argument = cli.input[0];
 let task;
 switch (argument) {
@@ -142,6 +136,8 @@ switch (argument) {
 		break;
 	case 'demo':
 	case 'd':
+	case 'develop':
+	case 'dev':
 		task = require('./tasks/demo');
 		break;
 	case 'install':
@@ -162,7 +158,11 @@ switch (argument) {
 		break;
 }
 
-if (task && cli.flags.watch) {
+if (task && (argument === 'develop' || argument === 'dev')) {
+	// start a server to show demos
+	const port = cli.flags.port || 8999;
+	startServer(port);
+	// build demos whenever changes are detected
 	let childProcess;
 	chokidar.watch(cli.flags.cwd || process.cwd(), {
 		ignored: [
@@ -184,10 +184,10 @@ if (task && cli.flags.watch) {
 				childProcess.kill();
 			}
 
-			childProcess = runWatchedTask(process.argv.slice(2));
+			childProcess = runWatchedTask(['demo']);
 		})
 		.on('ready', function () {
-			childProcess = runWatchedTask(process.argv.slice(2));
+			childProcess = runWatchedTask(['demo']);
 		});
 } else if (task) {
 	task(cli)
@@ -200,11 +200,9 @@ if (task && cli.flags.watch) {
 }
 
 function runWatchedTask(taskWithFlags) {
-	console.log('Press ctrl+c to exit.');
+	log.secondary('Press ctrl+c to exit.');
 	const commandLine = require('./helpers/command-line');
-	return commandLine.run(__filename, taskWithFlags.filter(flag => {
-		return flag !== '--watch' && flag !== '--run-server' && flag !== '--runServer';
-	}), {
+	return commandLine.run(__filename, taskWithFlags, {
 		cwd: cli.flags.cwd || process.cwd()
 	});
 }


### PR DESCRIPTION
Replaces:
`obt demo --run-server --watch --verbose --brand=internal`

With:
`obt dev --brand=internal`

https://github.com/Financial-Times/origami-build-tools/issues/735