### PR TITLE
Add demo command tests and fix a related bug.

### DIFF
--- a/lib/helpers/construct-polyfill-url.js
+++ b/lib/helpers/construct-polyfill-url.js
@@ -20,9 +20,9 @@ async function constructBrowserDeps() {
 
 	const features = Array.from(new Set(requiredFeatures));
 	if (features.length > 0) {
-		return `https://polyfill.io/v2/polyfill.js?features=,${features.join(',')}&flags=gated&unknown=polyfill`;
+		return `https://polyfill.io/v2/polyfill.min.js?features=,${features.join(',')}&flags=gated&unknown=polyfill`;
 	} else {
-		return 'https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill';
+		return 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill';
 	}
 }
 

--- a/lib/helpers/construct-polyfill-url.js
+++ b/lib/helpers/construct-polyfill-url.js
@@ -20,9 +20,9 @@ async function constructBrowserDeps() {
 
 	const features = Array.from(new Set(requiredFeatures));
 	if (features.length > 0) {
-		return `https://polyfill.io/v2/polyfill.min.js?features=,${features.join(',')}&flags=gated&unknown=polyfill`;
+		return `https://polyfill.io/v3/polyfill.min.js?features=,${features.join(',')}&flags=gated&unknown=polyfill`;
 	} else {
-		return 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill';
+		return 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill';
 	}
 }
 

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -6,6 +6,7 @@ const mergeDeep = require('merge-deep');
 const files = require('../helpers/files');
 const buildJs = require('../tasks/build-js');
 const buildSass = require('../tasks/build-sass');
+const constructPolyfillUrl = require('../helpers/construct-polyfill-url');
 const mustache = require('mustache');
 const denodeify = require('util').promisify;
 
@@ -154,29 +155,11 @@ function buildDemoHtml(buildConfig) {
 			configuredPartials.oDemoStyle = oDemoStyle;
 			configuredPartials.oDemoScript = oDemoScript;
 			configuredPartials.oDemoTpl = String(oDemoTpl);
-			return readFile(origamiJsonPath, {
-				encoding: 'utf8'
-			});
+
+			return constructPolyfillUrl();
 		})
-		.then(file => {
-			let origamiJson;
-			try {
-				origamiJson = JSON.parse(file);
-			} catch (error) {
-				const e = new Error(error + ' in ' + origamiJsonPath);
-				e.stack = '';
-				throw e;
-			}
-
-			let browserFeatures = [];
-			if (origamiJson.browserFeatures) {
-				browserFeatures = browserFeatures
-					.concat(origamiJson.browserFeatures.required || [])
-					.concat(origamiJson.browserFeatures.optional || []);
-			}
-			browserFeatures.push('default');
-			data.oDemoBrowserFeatures = browserFeatures;
-
+		.then(polyfillUrl => {
+			data.oDemoPolyfillUrl = polyfillUrl;
 			return loadPartials(partialsDir);
 		})
 		.then(p => {

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -118,7 +118,6 @@ function buildDemoHtml(buildConfig) {
 	const partialsDir = path.dirname(src);
 	const dest = path.join('demos', buildConfig.staticSource !== 'dist' ? 'local' : '');
 	const destName = buildConfig.demo.name + '.html';
-	const origamiJsonPath = path.join(buildConfig.cwd, 'origami.json');
 	let data;
 	let partials;
 	const configuredPartials = {};

--- a/templates/page.mustache
+++ b/templates/page.mustache
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>{{oDemoTitle}}</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="https://cdn.polyfill.io/v3/polyfill.min.js?features={{oDemoBrowserFeatures}}"></script>
+	<script src="{{oDemoPolyfillUrl}}"></script>
 	<style>
 		body {
 			margin: 0;

--- a/templates/page.mustache
+++ b/templates/page.mustache
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>{{oDemoTitle}}</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="{{oDemoPolyfillUrl}}"></script>
+	<script src="{{{oDemoPolyfillUrl}}}"></script>
 	<style>
 		body {
 			margin: 0;

--- a/test/integration/demo/demo.test.js
+++ b/test/integration/demo/demo.test.js
@@ -49,7 +49,7 @@ describe('obt demo', function () {
 		before(function () {
 			// copy fixture (example component with multiple demos)
 			// to a temporary test directory
-			fs.copySync(fixturesDirectory, testDirectory)
+			fs.copySync(fixturesDirectory, testDirectory);
 			process.chdir(testDirectory);
 			// update the demo configuration in origami.json so multiple demos
 			// have the same name
@@ -98,7 +98,7 @@ describe('obt demo', function () {
 		before(function () {
 			// copy fixture (example component with multiple demos)
 			// to a temporary test directory
-			fs.copySync(fixturesDirectory, testDirectory)
+			fs.copySync(fixturesDirectory, testDirectory);
 			process.chdir(testDirectory);
 			return obtBinPath()
 				.then(obt => {
@@ -111,7 +111,9 @@ describe('obt demo', function () {
 					try {
 						builtDemoHtml1 = fs.readFileSync(expectedBuiltDemoPath1, 'utf8');
 						builtDemoHtml2 = fs.readFileSync(expectedBuiltDemoPath2, 'utf8');
-					} catch {}
+					} catch(e) {
+						// assume no files found
+					}
 				});
 		});
 
@@ -200,7 +202,9 @@ describe('obt demo', function () {
 			try {
 				builtDemoCss1 = fs.readFileSync(expectedBuiltCssPath1, 'utf8');
 				builtDemoCss2 = fs.readFileSync(expectedBuiltCssPath2, 'utf8');
-			} catch { }
+			} catch(e) {
+				// assume files not found
+			}
 			// Confirm the css is as expected.
 			proclaim.include(
 				builtDemoCss1,
@@ -227,7 +231,9 @@ describe('obt demo', function () {
 			try {
 				builtDemoJs1 = fs.readFileSync(expectedBuiltJsPath1, 'utf8');
 				builtDemoJs2 = fs.readFileSync(expectedBuiltJsPath2, 'utf8');
-			} catch { }
+			} catch(e) {
+				// assume files not found
+			}
 			// Confirm the js is as expected.
 			proclaim.include(
 				builtDemoJs1,

--- a/test/integration/demo/demo.test.js
+++ b/test/integration/demo/demo.test.js
@@ -5,15 +5,16 @@ const execa = require('execa');
 const path = require('path');
 const process = require('process');
 const obtBinPath = require('../helpers/obtpath');
-/*
 const proclaim = require('proclaim');
 const fileExists = require('../helpers/fileExists');
-const rimraf = require('../helpers/delete');
-*/
+const uniqueTempDir = require('unique-temp-dir');
+const fs = require('fs-extra');
+const rimraf = require("../helpers/delete");
 
 describe('obt demo', function () {
 
 	this.timeout(60 * 1000);
+
 	describe('component with no demos', function () {
 
 		beforeEach(function () {
@@ -40,366 +41,209 @@ describe('obt demo', function () {
 		});
 	});
 
-	/*
-	describe('component with multiple demos', function () {
 
-		beforeEach(function () {
-			// Change the current working directory to the folder which contains the project we are testing against.
-			// We are doing this to replicate how obt is used when executed inside a terminal.
-			process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
+	describe('component with multiple demos with the same name', function () {
+		const testDirectory = uniqueTempDir({ create: true });
+		const fixturesDirectory = path.resolve(__dirname, 'fixtures/multiple-demos');
+
+		before(function () {
+			// copy fixture (example component with multiple demos)
+			// to a temporary test directory
+			fs.copySync(fixturesDirectory, testDirectory)
+			process.chdir(testDirectory);
+			// update the demo configuration in origami.json so multiple demos
+			// have the same name
+			const testManifestPath = path.resolve(testDirectory, 'origami.json');
+			const testManifestContent = fs.readFileSync(testManifestPath);
+			const testManifest = JSON.parse(testManifestContent);
+			testManifest.demos.push(Object.assign({}, testManifest.demos[0]));
+			fs.writeFileSync(testManifestPath, JSON.stringify(testManifest));
 		});
 
-		afterEach(function () {
-			// Change the current working directory back to the directory where you started running these tests from.
+		after(function () {
+			// remove temporary test directory
 			process.chdir(process.cwd());
+			return rimraf(testDirectory);
 		});
 
-		it('should not error', function () {
-			return obtBinPath()
+		it('should error', function (done) {
+			// Run obt demo
+			obtBinPath()
 				.then(obt => {
 					return execa(obt, ['demo']);
+				}).then(() => {
+					done(new Error('No error was thrown.'));
+				}).catch(e => {
+					try {
+						proclaim.include(
+							e.message,
+							'Demos with the same name were found'
+						);
+					} catch(e) {
+						done(e);
+					}
+					done();
+				});
+		});
+	});
+
+	describe('component with multiple valid demos', function () {
+		const testDirectory = uniqueTempDir({ create: true });
+		const fixturesDirectory = path.resolve(__dirname, 'fixtures/multiple-demos');
+		const expectedBuiltDemoPath1 = path.resolve(testDirectory, 'demos/local/demo-1.html');
+		const expectedBuiltDemoPath2 = path.resolve(testDirectory, 'demos/local/demo-2.html');
+		let builtDemoHtml1 = '';
+		let builtDemoHtml2 = '';
+
+		before(function () {
+			// copy fixture (example component with multiple demos)
+			// to a temporary test directory
+			fs.copySync(fixturesDirectory, testDirectory)
+			process.chdir(testDirectory);
+			return obtBinPath()
+				.then(obt => {
+					// Run obt demo
+					return execa(obt, ['demo']);
+				}).then(() => {
+					// Get the built demo html content we expect
+					// If the file is not found move on, later test
+					// assertions will cover that
+					try {
+						builtDemoHtml1 = fs.readFileSync(expectedBuiltDemoPath1, 'utf8');
+						builtDemoHtml2 = fs.readFileSync(expectedBuiltDemoPath2, 'utf8');
+					} catch {}
 				});
 		});
 
-		describe('demos with data stored in demo configuration', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		after(function () {
+			// remove temporary test directory
+			process.chdir(process.cwd());
+			return rimraf(testDirectory);
 		});
 
-		describe('demo with data stored in it\'s own specific demo configuration', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should have created a html file for each demo', function () {
+			proclaim.ok(
+				fileExists(expectedBuiltDemoPath1),
+				'Could not find the built demo html file for demo-1.'
+			);
+			proclaim.ok(
+				fileExists(expectedBuiltDemoPath2),
+				'Could not find the built demo html file for demo-2.'
+			);
 		});
 
-		describe('demo with it\'s own dependencies', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should have rendered demo html in the body of the demo template', function () {
+			proclaim.include(builtDemoHtml1, 'demo 1');
+			proclaim.include(builtDemoHtml2, 'demo 2');
 		});
 
-	});
-
-	describe('component with one demo', function () {
-
-		describe('component with no required browser features', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-required-browser-features'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should have included demo css in the demo html', function () {
+			proclaim.include(builtDemoHtml1, '<link rel="stylesheet" href="demo.css" />');
+			proclaim.include(builtDemoHtml2, '<link rel="stylesheet" href="demo-2.css" />');
 		});
 
-		describe('component with required browser features', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should have included demo javascript in the demo html', function () {
+			proclaim.include(builtDemoHtml1, '<script src="demo.js"></script>');
+			proclaim.include(builtDemoHtml2, '<script src="demo-2.js"></script>');
 		});
 
-		describe('component with optional browser features', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should have included required polyfills registered in origami.json', function () {
+			const expectedPolyfill = 'Array.from';
+			const regex = new RegExp(`<script [^>]+polyfill.io[^>]+${expectedPolyfill}`);
+			proclaim.match(
+				builtDemoHtml1,
+				regex,
+				`Demo 1 did not find the expected ${expectedPolyfill} polyfill.`
+			);
+			proclaim.match(
+				builtDemoHtml2,
+				regex,
+				`Demo 2 did not find the expected ${expectedPolyfill} polyfill.`
+			);
 		});
 
-		describe('demo using component\'s sass mixins', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should not include the `default` polyfill in demo html if not specified', function () {
+			const unexpectedPolyfill = 'default';
+			const regex = new RegExp(`<script [^>]+polyfill.io[^>]+${unexpectedPolyfill}`);
+			proclaim.notMatch(
+				builtDemoHtml1,
+				regex,
+				`Demo 1 had the ${unexpectedPolyfill} polyfill unexpectedly.`
+			);
+			proclaim.notMatch(
+				builtDemoHtml2,
+				regex,
+				`Demo 2 had the ${unexpectedPolyfill} polyfill unexpectedly.`
+			);
 		});
 
-		describe('demo using component\'s javascript API', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should add demo document classes', function () {
+			proclaim.match(builtDemoHtml1, /<html[^>]+class="[^"]+demo-1/, 'Did not find a `demo-1` class on the html element.');
+			proclaim.match(builtDemoHtml2, /<html[^>]+class="[^"]+demo-2/, 'Did not find a `demo-2` class on the html element.');
 		});
 
-		describe('demo using extra dependency component\'s javascript and sass', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should include a request to the Origami Build Service in demo markup for demo dependencies', function () {
+			// demo dependency css
+			proclaim.include(builtDemoHtml1, '<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts@^4.0.0" />');
+			proclaim.include(builtDemoHtml2, '<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts@^4.0.0" />');
+			// demo dependency js
+			proclaim.include(builtDemoHtml1, '<script src="https://origami-build.ft.com/v2/bundles/js?modules=o-fonts@^4.0.0"></script>');
+			proclaim.include(builtDemoHtml2, '<script src="https://origami-build.ft.com/v2/bundles/js?modules=o-fonts@^4.0.0"></script>');
 		});
 
-		describe('demo which has a bower conflict in it\'s dependencies', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should build demo css', function () {
+			const expectedBuiltCssPath1 = path.resolve(testDirectory, 'demos/local/demo.css');
+			const expectedBuiltCssPath2 = path.resolve(testDirectory, 'demos/local/demo-2.css');
+			let builtDemoCss1 = '';
+			let builtDemoCss2 = '';
+			// Get built css.
+			try {
+				builtDemoCss1 = fs.readFileSync(expectedBuiltCssPath1, 'utf8');
+				builtDemoCss2 = fs.readFileSync(expectedBuiltCssPath2, 'utf8');
+			} catch { }
+			// Confirm the css is as expected.
+			proclaim.include(
+				builtDemoCss1,
+				'.o-multiple-demos', 'Expected demo 1 css to include the class ".o-multiple-demos".'
+			);
+			proclaim.notInclude(
+				builtDemoCss1,
+				'.demo-two', 'Did not expected demo 1 css to include the demo 2 specific class ".demo-two".'
+			);
+			proclaim.include(
+				builtDemoCss2,
+				'.demo-two', 'Expected demo 2 css to include the demo specific class ".demo-2".'
+			);
 		});
 
-		describe('demos which have the same name', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
-		});
-
-		describe('building using custom demo configuration file', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
-		});
-
-		describe('demo with invalid sass', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
-		});
-
-		describe('demo with invalid javascript', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
-		});
-
-		describe('demo with invalid mustache template', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
-		});
-
-		describe('demo with data stored in demo configuration', function () {
-
-			beforeEach(function () {
-				// Change the current working directory to the folder which contains the project we are testing against.
-				// We are doing this to replicate how obt is used when executed inside a terminal.
-				process.chdir(path.join(__dirname, '/fixtures/no-js-or-sass'));
-			});
-
-			afterEach(function () {
-				// Change the current working directory back to the directory where you started running these tests from.
-				process.chdir(process.cwd());
-			});
-
-			it('should not error', function () {
-				return obtBinPath()
-					.then(obt => {
-						return execa(obt, ['demo']);
-					});
-			});
+		it('should build demo javascript', function () {
+			const expectedBuiltJsPath1 = path.resolve(testDirectory, 'demos/local/demo.js');
+			const expectedBuiltJsPath2 = path.resolve(testDirectory, 'demos/local/demo-2.js');
+			const expectedJsInDemo1 = 'oMultipleDemos.init()';
+			const expectedJsInDemo2 = 'console.log(demoTwo)';
+			let builtDemoJs1 = '';
+			let builtDemoJs2 = '';
+			// Get built js.
+			try {
+				builtDemoJs1 = fs.readFileSync(expectedBuiltJsPath1, 'utf8');
+				builtDemoJs2 = fs.readFileSync(expectedBuiltJsPath2, 'utf8');
+			} catch { }
+			// Confirm the js is as expected.
+			proclaim.include(
+				builtDemoJs1,
+				expectedJsInDemo1,
+				`Expected demo 1 js to include the javascript "${expectedJsInDemo1}".`
+			);
+			proclaim.notInclude(
+				builtDemoJs1,
+				expectedJsInDemo2,
+				'Did not expected demo 1 javascript to include the demo 2 specific javascript.'
+			);
+			proclaim.include(
+				builtDemoJs2,
+				expectedJsInDemo2,
+				'Expected demo 2 javascript to include demo specific javascript.'
+			);
 		});
 	});
-	*/
 });

--- a/test/integration/demo/fixtures/multiple-demos/bower.json
+++ b/test/integration/demo/fixtures/multiple-demos/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "o-multiple-demos",
+  "description": "a fixture to test the demo command of origami-build-tools",
+  "ignore": [
+    "node_modules",
+    "bower_components",
+    "build"
+  ],
+  "main": [
+    "main.scss",
+    "main.js"
+  ]
+}

--- a/test/integration/demo/fixtures/multiple-demos/demos/src/demo-1.mustache
+++ b/test/integration/demo/fixtures/multiple-demos/demos/src/demo-1.mustache
@@ -1,0 +1,1 @@
+<div class="o-multiple-demos" data-o-component="o-multiple-demos">demo 1</div>

--- a/test/integration/demo/fixtures/multiple-demos/demos/src/demo-2.js
+++ b/test/integration/demo/fixtures/multiple-demos/demos/src/demo-2.js
@@ -1,0 +1,2 @@
+const demoTwo = 'demo 2 here';
+console.log(demoTwo);

--- a/test/integration/demo/fixtures/multiple-demos/demos/src/demo-2.mustache
+++ b/test/integration/demo/fixtures/multiple-demos/demos/src/demo-2.mustache
@@ -1,0 +1,1 @@
+<div class="o-multiple-demos" data-o-component="o-multiple-demos">demo 2</div>

--- a/test/integration/demo/fixtures/multiple-demos/demos/src/demo-2.scss
+++ b/test/integration/demo/fixtures/multiple-demos/demos/src/demo-2.scss
@@ -1,0 +1,4 @@
+$demoTwo: 'demo 2 here';
+.demo-two {
+    content: $demoTwo;
+}

--- a/test/integration/demo/fixtures/multiple-demos/demos/src/demo.js
+++ b/test/integration/demo/fixtures/multiple-demos/demos/src/demo.js
@@ -1,0 +1,5 @@
+/*global require*/
+import './../../main.js';
+document.addEventListener('DOMContentLoaded', function() {
+	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+});

--- a/test/integration/demo/fixtures/multiple-demos/demos/src/demo.scss
+++ b/test/integration/demo/fixtures/multiple-demos/demos/src/demo.scss
@@ -1,0 +1,3 @@
+@import '../../main';
+
+@include oMultipleDemos();

--- a/test/integration/demo/fixtures/multiple-demos/demos/src/pa11y.mustache
+++ b/test/integration/demo/fixtures/multiple-demos/demos/src/pa11y.mustache
@@ -1,0 +1,8 @@
+<div>
+	<h1>Basic Demo</h1>
+	<div class="o-multiple-demos" data-o-component="o-multiple-demos"></div>
+</div>
+<div>
+	<h1>Basic Demo:hover</h1>
+	<div class="o-multiple-demos" data-o-component="o-multiple-demos"></div>
+</div>

--- a/test/integration/demo/fixtures/multiple-demos/main.js
+++ b/test/integration/demo/fixtures/multiple-demos/main.js
@@ -1,0 +1,7 @@
+import oMultipleDemos from './src/js/o-multiple-demos';
+const constructAll = function () {
+	oMultipleDemos.init();
+	document.removeEventListener('o.DOMContentLoaded', constructAll);
+};
+document.addEventListener('o.DOMContentLoaded', constructAll);
+export default oMultipleDemos;

--- a/test/integration/demo/fixtures/multiple-demos/main.scss
+++ b/test/integration/demo/fixtures/multiple-demos/main.scss
@@ -1,0 +1,21 @@
+@import 'src/scss/variables';
+
+/// Output all oMultipleDemos features
+/// @param {Map} $opts - A map of options to configure the output
+/// @access public
+/// @example scss
+///		@include oMultipleDemos($opts: (
+///			// your opts here
+///		))
+@mixin oMultipleDemos ($opts: ()) {
+	.o-multiple-demos {
+		background: #ffffff;
+	}
+}
+
+@if ($o-multiple-demos-is-silent == false) {
+	@include oMultipleDemos();
+
+	// Set to silent again to avoid being output twice
+	$o-multiple-demos-is-silent: true !global;
+}

--- a/test/integration/demo/fixtures/multiple-demos/origami.json
+++ b/test/integration/demo/fixtures/multiple-demos/origami.json
@@ -1,0 +1,44 @@
+{
+	"description": "a fixture to test the demo command of origami-build-tools",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": ["master"],
+	"support": "https://github.com/Financial-Times/o-multiple-demos/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+    "browserFeatures": {
+        "required": [
+            "Array.from"
+        ]
+    },
+    "demosDefaults": {
+        "js": "demos/src/demo.js",
+        "sass": "demos/src/demo.scss",
+        "dependencies": [
+            "o-fonts@^4.0.0"
+        ]
+    },
+    "demos": [
+        {
+            "title": "Demo One",
+            "name": "demo-1",
+            "template": "demos/src/demo-1.mustache",
+            "documentClasses": "demo-1",
+            "description": "This demo uses the default demo JavaScript and Sass."
+        },
+        {
+            "title": "Demo Two",
+            "name": "demo-2",
+            "template": "demos/src/demo-2.mustache",
+            "documentClasses": "demo-2",
+            "js": "demos/src/demo-2.js",
+            "sass": "demos/src/demo-2.scss",
+            "description": "This demo has its own JavaScript and Sass."
+        }
+    ]
+}

--- a/test/integration/demo/fixtures/multiple-demos/src/js/o-multiple-demos.js
+++ b/test/integration/demo/fixtures/multiple-demos/src/js/o-multiple-demos.js
@@ -1,0 +1,57 @@
+class OMultipleDemos {
+	/**
+	 * Class constructor.
+	 * @param {HTMLElement} [oMultipleDemosEl] - The component element in the DOM
+	 * @param {Object} [options={}] - An options object for configuring the component
+	 */
+	constructor (oMultipleDemosEl, opts) {
+		this.oMultipleDemosEl = oMultipleDemosEl;
+		this.options = Object.assign({}, {
+		}, opts || OMultipleDemos.getDataAttributes(oMultipleDemosEl));
+	}
+	/**
+	 * Get the data attributes from the OMultipleDemosElement. If the element is being set up
+	 * declaratively, this method is used to extract the data attributes from the DOM.
+	 * @param {HTMLElement} oMultipleDemosEl - The component element in the DOM
+	 */
+	static getDataAttributes (oMultipleDemosEl) {
+		if (!(oMultipleDemosEl instanceof HTMLElement)) {
+			return {};
+		}
+		return Object.keys(oMultipleDemosEl.dataset).reduce((options, key) => {
+			// Ignore data-o-component
+			if (key === 'oComponent') {
+				return options;
+			}
+			// Build a concise key and get the option value
+			const shortKey = key.replace(/^oMultipleDemos(w)(w+)$/, (m, m1, m2) => m1.toLowerCase() + m2);
+			const value = oMultipleDemosEl.dataset[key];
+			// Try parsing the value as JSON, otherwise just set it as a string
+			try {
+				options[shortKey] = JSON.parse(value.replace(/'/g, '"'));
+			} catch (error) {
+				options[shortKey] = value;
+			}
+			return options;
+		}, {});
+	}
+	/**
+	 * Initialise o-multiple-demos component.
+	 * @param {(HTMLElement|String)} rootElement - The root element to intialise the component in, or a CSS selector for the root element
+	 * @param {Object} [options={}] - An options object for configuring the component
+	 */
+	static init (rootEl, opts) {
+		if (!rootEl) {
+			rootEl = document.body;
+		}
+		if (!(rootEl instanceof HTMLElement)) {
+			rootEl = document.querySelector(rootEl);
+		}
+		if (rootEl instanceof HTMLElement && rootEl.matches('[data-o-component=o-multiple-demos]')) {
+			return new OMultipleDemos(rootEl, opts);
+		}
+		return Array.from(rootEl.querySelectorAll('[data-o-component="o-multiple-demos"]'), rootEl => new OMultipleDemos(rootEl, opts));
+	}
+}
+
+export default OMultipleDemos;

--- a/test/integration/demo/fixtures/multiple-demos/src/scss/_brand.scss
+++ b/test/integration/demo/fixtures/multiple-demos/src/scss/_brand.scss
@@ -1,0 +1,10 @@
+/// Helper for `o-brand` function.
+/// @access private
+@function _oMultipleDemosGet($variables, $from: null) {
+    @return oBrandGet($component: 'o-multiple-demos', $variables: $variables, $from: $from);
+}
+/// Helper for `o-brand` function.
+/// @access private
+@function _oMultipleDemosSupports($variant) {
+    @return oBrandSupportsVariant($component: 'o-multiple-demos', $variant: $variant);
+}

--- a/test/integration/demo/fixtures/multiple-demos/src/scss/_variables.scss
+++ b/test/integration/demo/fixtures/multiple-demos/src/scss/_variables.scss
@@ -1,0 +1,1 @@
+$o-multiple-demos-is-silent: true !default;

--- a/test/unit/helpers/construct-polyfill-url.test.js
+++ b/test/unit/helpers/construct-polyfill-url.test.js
@@ -64,7 +64,7 @@ describe('construct-polyfill-url', function() {
 			globby.resolves([]);
 			return constructPolyfillUrl()
 				.then(polyfillUrl => {
-					proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
+					proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
 				});
 		});
 	});
@@ -77,7 +77,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -89,7 +89,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -101,7 +101,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?features=,Array.prototype.every&flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=,Array.prototype.every&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -112,7 +112,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?features=,Array.prototype.every,Array.prototype.some&flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=,Array.prototype.every,Array.prototype.some&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -123,7 +123,7 @@ describe('construct-polyfill-url', function() {
 
 					return constructPolyfillUrl()
 						.then(polyfillUrl => {
-							proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
+							proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
 						});
 				});
 			});

--- a/test/unit/helpers/construct-polyfill-url.test.js
+++ b/test/unit/helpers/construct-polyfill-url.test.js
@@ -64,7 +64,7 @@ describe('construct-polyfill-url', function() {
 			globby.resolves([]);
 			return constructPolyfillUrl()
 				.then(polyfillUrl => {
-					proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
+					proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
 				});
 		});
 	});
@@ -77,7 +77,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -89,7 +89,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -101,7 +101,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.js?features=,Array.prototype.every&flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?features=,Array.prototype.every&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -112,7 +112,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.js?features=,Array.prototype.every,Array.prototype.some&flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?features=,Array.prototype.every,Array.prototype.some&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -123,7 +123,7 @@ describe('construct-polyfill-url', function() {
 
 					return constructPolyfillUrl()
 						.then(polyfillUrl => {
-							proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.js?flags=gated&unknown=polyfill');
+							proclaim.equal(polyfillUrl, 'https://polyfill.io/v2/polyfill.min.js?flags=gated&unknown=polyfill');
 						});
 				});
 			});


### PR DESCRIPTION
The polyfill url in demos includes the `default` set, which we
had intended to remove to ensure we catch errors where a
JavaScript feature is not supported by the browser. Only polyfills
which have been explicitly specified in `origami.json` should be
included in demos.

However we only removed the `default` set for Karma tests by mistake:
https://github.com/Financial-Times/origami-build-tools/pull/623