### PR TITLE
Always show Sass debug and warning notices.

### DIFF
--- a/lib/tasks/build-sass.js
+++ b/lib/tasks/build-sass.js
@@ -46,7 +46,6 @@ function getSassData(sassFile, config = {
  * @param {String|Undefined} config.brand [undefined] - The brand the Sass build is for .e.g. "master", "internal", or "whitelabel".
  * @param {String|Undefined} config.sassPrefix [undefined] - Sass to prefix the Sass from file with.
  * @param {String} config.outputStyle ['expanded'] - The Sass output style. One of `compressed` (removes as many extra characters as possible) or `expanded` (writes each selector and declaration on its own line).
- * @param {Boolean} config.verbose [true] - When true, Sass warnings and debug messages are output.
  * @param {String[]} config.sassIncludePaths - Extra Sass paths to includes.
  * @param {Boolean} config.ignoreBower - True to include npm Sass paths, otherwise bower paths are used.
  * @return {String} - The built css.
@@ -65,7 +64,6 @@ module.exports = function buildSass(config) {
 				brand: config.brand,
 				sassPrefix: config.sassPrefix,
 			});
-			const verbose = 'verbose' in config ? config.verbose : true;
 
 			return Promise.resolve(sassData)
 				.then(sassData => {
@@ -84,10 +82,6 @@ module.exports = function buildSass(config) {
 						['--embed-source-map', '--source-map-urls=absolute'] :
 						['--no-source-map'],
 					);
-					// Only emit warnings or debug notices when in verbose mode
-					if (!verbose) {
-						sassArguments.push('--quiet');
-					}
 					// Build Sass
 					let result = '';
 					try {

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -48,8 +48,7 @@ function buildDemoSass(buildConfig) {
 				buildFolder: dest,
 				ignoreBower: buildConfig.ignoreBower,
 				cwd: buildConfig.cwd,
-				brand: buildConfig.brand,
-				verbose: buildConfig.verbose
+				brand: buildConfig.brand
 			};
 
 			return buildSass(sassConfig);
@@ -342,7 +341,6 @@ module.exports = function (cfg) {
 			for (const demo of demos) {
 				const buildConfig = {
 					demo: demo || {},
-					verbose: config.verbose,
 					brand: config.brand,
           			staticSource: config.production ? 'dist' : undefined,
 					cwd: cwd,

--- a/test/unit/tasks/build-sass.test.js
+++ b/test/unit/tasks/build-sass.test.js
@@ -93,7 +93,7 @@ describe('Build Sass', function () {
 			});
 	});
 
-	it('outputs warnings and debug messages when verbose mode is enabled', function () {
+	it('outputs warnings and debug messages', function () {
 		const debugMessage = `This is a debug message!`;
 		const warningMessage = `This is a warning!`;
 		const debugSass = `@debug "${debugMessage};";`;
@@ -101,30 +101,11 @@ describe('Build Sass', function () {
 		const logSpy = sinon.spy(log, 'secondary');
 		return build({
 			buildCss: 'bundle.css',
-			sassPrefix: debugSass + warningSass,
-			verbose: true
+			sassPrefix: debugSass + warningSass
 		})
 			.then(() => {
 				proclaim.isTrue(logSpy.calledWithMatch(debugMessage), 'Did not log Sass debug messages.');
 				proclaim.isTrue(logSpy.calledWithMatch(warningMessage), 'Did not log Sass warnings.');
-				logSpy.restore();
-			});
-	});
-
-	it('does not output warnings or debug messages when verbose mode is not enabled', function () {
-		const debugMessage = `This is a debug message!`;
-		const warningMessage = `This is a warning!`;
-		const debugSass = `@debug "${debugMessage};";`;
-		const warningSass = `@warn "${warningMessage};";`;
-		const logSpy = sinon.spy(log, 'secondary');
-		return build({
-			buildCss: 'bundle.css',
-			sassPrefix: debugSass + warningSass,
-			verbose: false
-		})
-			.then(() => {
-				proclaim.isFalse(logSpy.calledWithMatch(debugMessage), 'Logged Sass debug messages unexpectedly.');
-				proclaim.isFalse(logSpy.calledWithMatch(warningMessage), 'Logged Sass warnings unexpectedly.');
 				logSpy.restore();
 			});
 	});


### PR DESCRIPTION
We removed the `--verbose` flag but did not set `verbose: true`
by default. In other words, the `verbose` option still existed
but had no cli flag to set it to true.

Remove the verbose option all together and update our unit tests
to always expect debug output from Sass builds