### PR TITLE
Move `stylelint-order` to `dependencies` from `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7854,7 +7854,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
       "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.14",
         "postcss": "^7.0.17"
@@ -7863,8 +7862,7 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },
@@ -10317,7 +10315,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.0.0.tgz",
       "integrity": "sha512-bXV0v+jfB0+JKsqIn3mLglg1Dj2QCYkFHNfL1c+rVMEmruZmW5LUqT/ARBERfBm8SFtCuXpEdatidw/3IkcoiA==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.15",
         "postcss": "^7.0.26",
@@ -10327,8 +10324,7 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -948,12 +948,6 @@
         }
       }
     },
-    "acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-      "dev": true
-    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -4510,15 +4504,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-1.1.0.tgz",
       "integrity": "sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE="
-    },
-    "is-es5-syntax": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-es5-syntax/-/is-es5-syntax-1.0.1.tgz",
-      "integrity": "sha512-8bkLCq6bV+h5+/7zHUYVTqwNRPmpxcXbMeMVuiX64++As6Yl1WhOCDt9kKoFzXpL8qu7fr+VBxAGxeOKHxvjRg==",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.0.3"
-      }
     },
     "is-extendable": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "snyk": "^1.317.0",
     "stylelint": "^13.2.1",
     "stylelint-scss": "^3.17.1",
+    "stylelint-order": "^4.0.0",
     "update-notifier": "^4.1.0"
   },
   "devDependencies": {
@@ -80,8 +81,7 @@
     "node-version": "^2.0.0",
     "npm-prepublish": "^1.2.3",
     "rimraf": "^3.0.2",
-    "unique-temp-dir": "^1.0.0",
-    "stylelint-order": "^4.0.0"
+    "unique-temp-dir": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-objects": "^1.1.1",
     "eslint-plugin-promise": "^4.2.1",
-    "is-es5-syntax": "^1.0.1",
     "nixt": "^0.5.1",
     "node-version": "^2.0.0",
     "npm-prepublish": "^1.2.3",


### PR DESCRIPTION
**Move `stylelint-order` to `dependencies` from `devDependencies`**
`obt verify` errors when installed globally, as `stylelint-order` cannot be found. I assume this is why.

**Remove `is-es5-syntax` as a dev dependency, as it is not used.**