### PR TITLE
Allow `oGridRespondTo` after declarations when linting Sass.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10290,9 +10290,9 @@
       }
     },
     "stylelint-config-origami-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-origami-component/-/stylelint-config-origami-component-1.0.1.tgz",
-      "integrity": "sha512-RiEIWPszVXlQ/z73aayl5vxd7q41SNEPcghzF5l0xLiIPKMkAR++/GV7pAueqPHKZbcmFGP+ye4b+N7TSGG/Jw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stylelint-config-origami-component/-/stylelint-config-origami-component-1.0.2.tgz",
+      "integrity": "sha512-rjOrHDIGNrPI8VpBMgvD/V9anliLKdZOiz6u/fyvdMwcHjaLiIPc4N5+mWeeKCCkkeZEAXUq2clAsO3ar6MGGg==",
       "requires": {
         "stylelint-order": "^4.0.0",
         "stylelint-scss": "^3.17.1"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sinon": "^9.0.2",
     "snyk": "^1.319.0",
     "stylelint": "^13.2.1",
-    "stylelint-config-origami-component": "^1.0.1",
+    "stylelint-config-origami-component": "^1.0.2",
     "update-notifier": "^4.1.0"
   },
   "devDependencies": {

--- a/test/unit/fixtures/verify/src/scss/mixins-before-declarations/valid.scss
+++ b/test/unit/fixtures/verify/src/scss/mixins-before-declarations/valid.scss
@@ -17,6 +17,6 @@
 }
 
 .foo {
-	@include oGridRespondTo();
 	content: 'baz';
+	@include oGridRespondTo();
 }


### PR DESCRIPTION
`oGridRespondTo` outputs a media query.