### PR TITLE
Update Sass linting to allow newlines in declarations and functions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,7 +3153,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -10097,9 +10097,9 @@
       }
     },
     "stylelint-config-origami-component": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stylelint-config-origami-component/-/stylelint-config-origami-component-1.0.2.tgz",
-      "integrity": "sha512-rjOrHDIGNrPI8VpBMgvD/V9anliLKdZOiz6u/fyvdMwcHjaLiIPc4N5+mWeeKCCkkeZEAXUq2clAsO3ar6MGGg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-config-origami-component/-/stylelint-config-origami-component-1.0.3.tgz",
+      "integrity": "sha512-p1D8e1j9wkNUJV+R7ecwpjXTU0X6yY//wA9MBI+74+ulEkX/duPn0lEflYIkGOVJszoq4TFPyqlaO4Os7LdAyQ==",
       "requires": {
         "stylelint-order": "^4.0.0",
         "stylelint-scss": "^3.17.1"
@@ -10116,15 +10116,15 @@
       }
     },
     "stylelint-scss": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.17.1.tgz",
-      "integrity": "sha512-KywqqHfK1otZv1QJA4xJDgcPJp1/cP3jnABpbU9gmXOKqKt8cNt27Imsh9JhY133X8D4zDh/38pNq4WjVfUQWQ==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.17.2.tgz",
+      "integrity": "sha512-e0dmxqsofy/HZj4urcGSJw4S6yHDJxiQdT20/1ciCsd5lomisa7YM4+Qtt1EG4hsqEG1dbEeF855tec1UyqcSA==",
       "requires": {
         "lodash": "^4.17.15",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.0.3"
+        "postcss-value-parser": "^4.1.0"
       }
     },
     "sudo-block": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sinon": "^9.0.2",
     "snyk": "^1.319.0",
     "stylelint": "^13.2.1",
-    "stylelint-config-origami-component": "^1.0.2",
+    "stylelint-config-origami-component": "^1.0.3",
     "update-notifier": "^4.1.0"
   },
   "devDependencies": {

--- a/test/unit/fixtures/verify/src/scss/space-after-colon/valid.scss
+++ b/test/unit/fixtures/verify/src/scss/space-after-colon/valid.scss
@@ -1,0 +1,7 @@
+.foo-grid {
+	grid-template-areas:
+		"header header header"
+		". sidebar ."
+		". main ."
+		"footer footer footer";
+}

--- a/test/unit/fixtures/verify/src/scss/space-between-parens/valid.scss
+++ b/test/unit/fixtures/verify/src/scss/space-between-parens/valid.scss
@@ -12,6 +12,14 @@
 	width: calc(100% - 10px);
 }
 
+
+$some-very-very-very-large-conditional: true;
+$foreground-color: if(
+	$some-very-very-very-large-conditional == true,
+	"then each argument should go on a newline for readability",
+	"otherwise each argument could be on the same line"
+);
+
 // We do not lint against Sass parameter spaces.
 // Previously origami-build-tools did lint for this, but
 // no stylelint rule appears to exist at time of writing


### PR DESCRIPTION
This is useful for formatting functions with large arguments in a
readable way:
```scss
$some-very-very-very-large-conditional: true;
$foreground-color: if(
	$some-very-very-very-large-conditional == true,
	"then each argument should go on a newline for readability",
	"otherwise each argument could be on the same line"
);
```

And for formatting declarations such as grid areas in a readable
way:
```scss
.foo-grid {
	grid-template-areas:
		"header header header"
		". sidebar ."
		". main ."
		"footer footer footer";
}
```