### PR TITLE
Use scrumple's new --allow-npm-dev-deps argument

### DIFF
--- a/lib/karma-scrumple.js
+++ b/lib/karma-scrumple.js
@@ -15,6 +15,7 @@ function createPreprocessor(config, logger) {
 		scrumpleArguments.push(`--input ${file.originalPath}`);
 		if (!config.ignoreBower) {
 			scrumpleArguments.push(`--for-bower`);
+			scrumpleArguments.push(`--allow-npm-dev-deps`);
 		}
 
 		const scrumpleCommand = scrumplePath + ' ' + scrumpleArguments.join(' ');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3143,7 +3143,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -8336,9 +8336,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scrumple": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/scrumple/-/scrumple-1.1.0.tgz",
-      "integrity": "sha512-gyYmR4++qhorQhHtvCLJWEbRe1PldfV4Oj2Ww430TARyEyKF6wBm7XCsjbT6LX2udCYdbbWV5skgpqXEVz414g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scrumple/-/scrumple-1.2.1.tgz",
+      "integrity": "sha512-dn8fmadsY0buvfJ3zaDOElFxdPESkQ+NTrQUE9QqiMSHsV3pMQAcC9kmOozWNr3tF1uz8v3eoLmwtJHQwQo50g==",
       "requires": {
         "@financial-times/scrumple-darwin": "*",
         "@financial-times/scrumple-linux-64": "*",
@@ -8346,21 +8346,21 @@
       },
       "dependencies": {
         "@financial-times/scrumple-darwin": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/scrumple-darwin/-/scrumple-darwin-1.1.0.tgz",
-          "integrity": "sha512-iPXgPSAZ5TVr2mYKwfRbVcyEnZiooZv2ty5s/gaZXcZUGlCkUa0WfEH+ZfabSQITuw0F7PLCSqlsTW4xbt1c7Q==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/scrumple-darwin/-/scrumple-darwin-1.2.1.tgz",
+          "integrity": "sha512-J5si8O8G3zLCey+ZbGx+rHWuXpw+IMzgR9BNGbAxIlW18Zuqcq4U5HS6dqM4JBR+Y5rrxpcm8PafvZ2+xcFWvQ==",
           "optional": true
         },
         "@financial-times/scrumple-linux-64": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/scrumple-linux-64/-/scrumple-linux-64-1.1.0.tgz",
-          "integrity": "sha512-TwkK7H+Sb5CwuSEz07HbnMUnhsZWJFicE9PUxQJT5j/WQ1KtAizSaBRqmZgsz0RfE+6cfRfzfLfqXqQvt44m9Q==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/scrumple-linux-64/-/scrumple-linux-64-1.2.1.tgz",
+          "integrity": "sha512-pCH5ZxhauiSfYOMaO/QDH74JvXA2dvT6Q1elsCfBdBudzR671EhInyR+I6K28nZRoNyeJhZHvF8GUW9cw0eUUA==",
           "optional": true
         },
         "@financial-times/scrumple-windows-64": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/scrumple-windows-64/-/scrumple-windows-64-1.1.0.tgz",
-          "integrity": "sha512-oC9a9lfb+AFJneISaVdZsNFa0dSwH8Qz6LN2sAjWEKUUQghfJb0C0QNxtoKjQg07cGlKfQzAkELx6i3KPOwpqw==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/scrumple-windows-64/-/scrumple-windows-64-1.2.1.tgz",
+          "integrity": "sha512-sx/Sug16FX0YHbB/CwFdLWIKPbGlNuV4hVXCw/r7iDR/3nuQxM5cIlypzBDb0EKdVdllSNfmgac9nttryfMmhA==",
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "proclaim": "^3.6.0",
     "root-check": "^1.0.0",
     "sass-true": "^5.0.0",
-    "scrumple": "^1.1.0",
+    "scrumple": "^1.2.1",
     "serve-handler": "^6.1.2",
     "sinon": "^9.0.2",
     "snyk": "^1.319.0",


### PR DESCRIPTION
because we're updating the tool to align with [the spec](https://origami.ft.com/spec/v1/components/#npm), we will release it as a patch.