### PR TITLE
Allow Sass sourcemaps to be disabled.

### DIFF
--- a/lib/tasks/build-sass.js
+++ b/lib/tasks/build-sass.js
@@ -59,7 +59,9 @@ module.exports = function buildSass(config) {
 		if (sassFile) {
 			const destFolder = config.buildFolder || files.getBuildFolderPath(cwd);
 			const dest = config.buildCss || 'main.css';
-			const useSourceMaps = config.sourcemaps || true;
+			const useSourceMaps = typeof config.sourcemaps === 'boolean' ?
+				config.sourcemaps :
+				true;
 			const sassData = getSassData(sassFile, {
 				brand: config.brand,
 				sassPrefix: config.sassPrefix,

--- a/test/unit/tasks/build-sass.test.js
+++ b/test/unit/tasks/build-sass.test.js
@@ -153,4 +153,27 @@ describe('Build Sass', function () {
 				proclaim.include(result, 'div {\n  color: blue;\n}');
 			});
 	});
+
+	it('should output source maps by default', function () {
+		return build({
+			sass: 'demos/src/demo-scss/demo.scss'
+		})
+			.then(function (result) {
+				const builtCss = fs.readFileSync('build/main.css', 'utf8');
+				proclaim.include(builtCss, '/*# sourceMappingURL=');
+				proclaim.include(result, '/*# sourceMappingURL=');
+			});
+	});
+
+	it('should not not output a source map when the sourcemaps option is false', function () {
+		return build({
+			sass: 'demos/src/demo-scss/demo.scss',
+			sourcemaps: false
+		})
+			.then(function (result) {
+				const builtCss = fs.readFileSync('build/main.css', 'utf8');
+				proclaim.doesNotInclude(builtCss, '/*# sourceMappingURL=');
+				proclaim.doesNotInclude(result, '/*# sourceMappingURL=');
+			});
+	});
 });


### PR DESCRIPTION
For example, whilst running compilation tests:
https://github.com/Financial-Times/origami-build-tools/pull/780