### PR TITLE
Use axe instead of htmlcs as axe find more errors

### DIFF
--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -15,7 +15,10 @@ const pa11yTest = async function (config) {
 
 	// Run the Pa11y tests
 	const results = await pa11y(src, {
-		ignore
+		ignore,
+		runners: [
+			'axe'
+		]
 	});
 
 	// Process and return the results


### PR DESCRIPTION
I've been making an inaccessible table to test pa11y and it kept passing instead of failing, I then found out that is because htmlcs does not find the issues but axe does.

htmlcs results
```
❯ npx pa11y --runner htmlcs ./demos/local/pa11y.html
Downloading Chromium r686378 - 110.2 Mb [====================] 100% 0.0s 
Welcome to Pa11y
 > Running Pa11y on URL file:///Users/jake.champion/Code/repo-data-cli/repos/o-table/demos/local/pa11y.html
No issues found!
```

axe results
```
❯ npx pa11y --runner axe ./demos/local/pa11y.html
Downloading Chromium r686378 - 110.2 Mb [====================] 100% 0.0s 
Welcome to Pa11y
 > Running Pa11y on URL file:///Users/jake.champion/Code/repo-data-cli/repos/o-table/demos/local/pa11y.html
Results for URL: file:///Users/jake.champion/Code/repo-data-cli/repos/o-table/demos/local/pa11y.html
 • Error: ARIA attributes must conform to valid names (https://dequeuniversity.com/rules/axe/3.5/aria-valid-attr?application=axeAPI)
   ├── aria-valid-attr
   ├── html > body > table
   └── <table aria-descrsibedby="demo-foooootnote-overflow" class="o-table o-table--horizontal-lines o-table--responsive-overflow o-table--sortable" data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="2" data-o-tabl...
 • Error: Document must have one main landmark (https://dequeuniversity.com/rules/axe/3.5/landmark-one-main?application=axeAPI)
   ├── landmark-one-main
   ├── html
   └── <html lang="en" class="o-hoverable-on demo-js"><head> <meta charset="utf-8"> ...</html>
 • Error: Page must contain a level-one heading (https://dequeuniversity.com/rules/axe/3.5/page-has-heading-one?application=axeAPI)
   ├── page-has-heading-one
   ├── html
   └── <html lang="en" class="o-hoverable-on demo-js"><head> <meta charset="utf-8"> ...</html>
 • Error: All page content must be contained by landmarks (https://dequeuniversity.com/rules/axe/3.5/region?application=axeAPI)
   ├── region
   ├── html > body > table
   └── <table aria-descrsibedby="demo-foooootnote-overflow" class="o-table o-table--horizontal-lines o-table--responsive-overflow o-table--sortable" data-o-component="o-table" data-o-table-responsive="overflow" data-o-table-minimum-row-count="2" data-o-tabl...
4 Errors
```