### PR TITLE
When running in CI, make the mocha reporter easier to work with for problem matchers.

### DIFF
--- a/config/karma.config.js
+++ b/config/karma.config.js
@@ -63,7 +63,7 @@ module.exports.getBaseKarmaConfig = function (opts = { ignoreBower: false }) {
 			// preprocess matching files before serving them to the browser
 			// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 			preprocessors: {
-				'test/**/*.js': ['scrumple'],
+				'test/**/*.js': ['scrumple', 'sourcemap'],
 				'main.scss': ['scss']
 			},
 			scssPreprocessor: {

--- a/lib/karma-scrumple.js
+++ b/lib/karma-scrumple.js
@@ -12,7 +12,7 @@ function createPreprocessor(config, logger) {
 		const location = path.relative(config.basePath, originalPath);
 
 		const scrumpleArguments = [];
-		scrumpleArguments.push(`--input ${file.originalPath}`);
+		scrumpleArguments.push(`--map-inline --input ${file.originalPath}`);
 		if (!config.ignoreBower) {
 			scrumpleArguments.push(`--for-bower`);
 			scrumpleArguments.push(`--allow-npm-dev-deps`);

--- a/lib/plugins/listr-karma.js
+++ b/lib/plugins/listr-karma.js
@@ -36,10 +36,10 @@ module.exports = function (currentWorkingDirectory) {
 								const error = value.log.map(log => formatError(log, '\t')).join('\n').split('\n').filter(log => log.trim().length);
 								const message = error.shift().trim();
 								const file = error.pop().trim().replace('at ', '');
-								const fullFilePath = path.join(currentWorkingDirectory, file);
+								// const fullFilePath = path.join(currentWorkingDirectory, file);
 								const fullTestDescription = value.suite.map((suite) => suite + ' > ').join('') + value.description;
 
-								errors.push(colors.white(fullFilePath) + ' ' + fullTestDescription);
+								errors.push(colors.white(file) + ' ' + fullTestDescription);
 								errors.push(colors.white(browser.name + ' errored with:') + ' ' + colors.red(message));
 							} else {
 								errors.push(colors.white(value.suite.map((value) => value + ' > ').join('') + value.description));

--- a/lib/plugins/listr-karma.js
+++ b/lib/plugins/listr-karma.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const colors = require('colors/safe');
-const path = require('path');
 const isCI = require('is-ci');
 
-module.exports = function (currentWorkingDirectory) {
+module.exports = function () {
 
 	const errors = [];
 
@@ -36,7 +35,6 @@ module.exports = function (currentWorkingDirectory) {
 								const error = value.log.map(log => formatError(log, '\t')).join('\n').split('\n').filter(log => log.trim().length);
 								const message = error.shift().trim();
 								const file = error.pop().trim().replace('at ', '');
-								// const fullFilePath = path.join(currentWorkingDirectory, file);
 								const fullTestDescription = value.suite.map((suite) => suite + ' > ').join('') + value.description;
 
 								errors.push(colors.white(file) + ' ' + fullTestDescription);

--- a/lib/plugins/listr-karma.js
+++ b/lib/plugins/listr-karma.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const colors = require('colors/safe');
+const path = require('path');
+const isCI = require('is-ci');
 
-module.exports = function () {
+module.exports = function (currentWorkingDirectory) {
 
 	const errors = [];
 
@@ -30,12 +32,23 @@ module.exports = function () {
 
 							++totalTestsFailed;
 
-							errors.push(colors.white(value.suite.map((value) => value + ' > ').join('') + value.description));
+							if (isCI) {
+								const error = value.log.map(log => formatError(log, '\t')).join('\n').split('\n').filter(log => log.trim().length);
+								const message = error.shift().trim();
+								const file = error.pop().trim().replace('at ', '');
+								const fullFilePath = path.join(currentWorkingDirectory, file);
+								const fullTestDescription = value.suite.map((suite) => suite + ' > ').join('') + value.description;
 
-							const msg = value.log.map(log => formatError(log, '\t')).join('\n').split('\n');
+								errors.push(colors.white(fullFilePath) + ' ' + fullTestDescription);
+								errors.push(colors.white(browser.name + ' errored with:') + ' ' + colors.red(message));
+							} else {
+								errors.push(colors.white(value.suite.map((value) => value + ' > ').join('') + value.description));
 
-							errors.push(colors.red(msg.shift()));
-							errors.push(colors.red(msg.join('\n')));
+								const msg = value.log.map(log => formatError(log, '\t')).join('\n').split('\n');
+
+								errors.push(colors.red(msg.shift()));
+								errors.push(colors.red(msg.join('\n')));
+							}
 						});
 					}
 				}

--- a/lib/tasks/karma.js
+++ b/lib/tasks/karma.js
@@ -45,7 +45,7 @@ const karmaTest = function (config, task) {
 			const Server = require('karma').Server;
 			const server = new Server(karmaConfig, exitCode => {
 				if (exitCode !== 0) {
-					task.title += `Failed Karma tests: ${'\n\n    ' + errors.join('\n\n    ')}`;
+					task.title += `Failed Karma tests: ${'\n\n    ' + errors.join('\n    ')}`;
 					reject(new Error(`Failed Karma tests`));
 				} else {
 					resolve();

--- a/lib/tasks/karma.js
+++ b/lib/tasks/karma.js
@@ -36,7 +36,7 @@ const karmaTest = function (config, task) {
 				karmaConfig.singleRun = false;
 			}
 
-			const { reporter, errors } = require('../plugins/listr-karma')(config.cwd);
+			const { reporter, errors } = require('../plugins/listr-karma')();
 
 			karmaConfig.files.unshift(polyfillUrl);
 			karmaConfig.plugins.unshift(reporter);

--- a/lib/tasks/karma.js
+++ b/lib/tasks/karma.js
@@ -36,7 +36,7 @@ const karmaTest = function (config, task) {
 				karmaConfig.singleRun = false;
 			}
 
-			const { reporter, errors } = require('../plugins/listr-karma')();
+			const { reporter, errors } = require('../plugins/listr-karma')(config.cwd);
 
 			karmaConfig.files.unshift(polyfillUrl);
 			karmaConfig.plugins.unshift(reporter);

--- a/test/unit/plugins/listr-karma.test.js
+++ b/test/unit/plugins/listr-karma.test.js
@@ -82,7 +82,7 @@ describe('SpecReporter', function () {
 						failedSpec = {
 							suite: ['suite name'],
 							description: 'description of test',
-							log: ['log message']
+							log: ['log', 'message']
 						};
 						newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
 						newSpecReporter.currentSuite.push(failedSpec.suite);

--- a/test/unit/plugins/listr-karma.test.js
+++ b/test/unit/plugins/listr-karma.test.js
@@ -16,20 +16,6 @@ describe('SpecReporter', function () {
 	let SpecReporter;
 	let errors;
 
-	beforeEach(function() {
-		mockery.enable({
-			useCleanCache: true,
-			warnOnReplace: false,
-			warnOnUnregistered: false
-		});
-		mockery.registerMock('is-ci', false);
-		mockery.registerAllowable('../../../lib/plugins/listr-karma.js');
-
-		const listrKarmaReporter = require('../../../lib/plugins/listr-karma.js')();
-		SpecReporter = listrKarmaReporter.reporter['reporter:listr'];
-		errors = listrKarmaReporter.errors;
-	});
-
 	afterEach(() => {
 		mockery.resetCache();
 		mockery.deregisterAll();
@@ -37,39 +23,30 @@ describe('SpecReporter', function () {
 	});
 
 	describe('functionality', function () {
-		describe('onRunComplete', function () {
-			describe('with no browsers', function () {
-				let newSpecReporter;
-
-				beforeEach(function () {
-					newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
-
-					newSpecReporter.currentSuite.push('suite name');
-					newSpecReporter.onRunComplete([], []);
+		context('running in a CI environment', function() {
+			beforeEach(function() {
+				mockery.enable({
+					useCleanCache: true,
+					warnOnReplace: false,
+					warnOnUnregistered: false
 				});
+				mockery.registerMock('is-ci', true);
+				mockery.registerAllowable('../../../lib/plugins/listr-karma.js');
 
-				it('should reset failedSpecs object', function () {
-					proclaim.deepEqual(newSpecReporter.failedSpecs, {});
-				});
-
-				it('should reset currentSuite arrays', function () {
-					proclaim.equal(newSpecReporter.currentSuite.length, 0);
-				});
-
-				it('should not add anything to the errors array', function () {
-					proclaim.equal(errors.length, 0);
-				});
+				const listrKarmaReporter = require('../../../lib/plugins/listr-karma.js')();
+				SpecReporter = listrKarmaReporter.reporter['reporter:listr'];
+				errors = listrKarmaReporter.errors;
 			});
 
-			describe('with browsers', function () {
-				describe('and there are no failures', function () {
+			describe('onRunComplete', function () {
+				describe('with no browsers', function () {
 					let newSpecReporter;
 
 					beforeEach(function () {
 						newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
-						newSpecReporter.onRunComplete(['testValue'], {
-							failed: 0
-						});
+
+						newSpecReporter.currentSuite.push('suite name');
+						newSpecReporter.onRunComplete([], []);
 					});
 
 					it('should reset failedSpecs object', function () {
@@ -85,28 +62,161 @@ describe('SpecReporter', function () {
 					});
 				});
 
-				describe('and there are failures', function () {
-					let newSpecReporter;
-					let browser;
-					let failedSpec;
-					beforeEach(function () {
-						browser = {
-							name: 'Test Browser',
-							id: 'testValue'
-						};
-						failedSpec = {
-							suite: ['suite name'],
-							description: 'description of test',
-							log: ['log', 'message']
-						};
-						newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
-						newSpecReporter.currentSuite.push(failedSpec.suite);
-						newSpecReporter.failedSpecs = {
-							[browser.id]: [failedSpec]
-						};
-						newSpecReporter.onRunComplete([browser], {
-							failed: 1
+				describe('with browsers', function () {
+					describe('and there are no failures', function () {
+						let newSpecReporter;
+
+						beforeEach(function () {
+							newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
+							newSpecReporter.onRunComplete(['testValue'], {
+								failed: 0
+							});
 						});
+
+						it('should reset failedSpecs object', function () {
+							proclaim.deepEqual(newSpecReporter.failedSpecs, {});
+						});
+
+						it('should reset currentSuite arrays', function () {
+							proclaim.equal(newSpecReporter.currentSuite.length, 0);
+						});
+
+						it('should not add anything to the errors array', function () {
+							proclaim.equal(errors.length, 0);
+						});
+					});
+
+					describe('and there are failures', function () {
+						let newSpecReporter;
+						let browser;
+						let failedSpec;
+						beforeEach(function () {
+							browser = {
+								name: 'Test Browser',
+								id: 'testValue'
+							};
+							failedSpec = {
+								suite: ['suite name'],
+								description: 'description of test',
+								log: ['log', 'test/add.test.js']
+							};
+							newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
+							newSpecReporter.currentSuite.push(failedSpec.suite);
+							newSpecReporter.failedSpecs = {
+								[browser.id]: [failedSpec]
+							};
+							newSpecReporter.onRunComplete([browser], {
+								failed: 1
+							});
+						});
+
+						it('should reset failedSpecs object', function () {
+							proclaim.deepEqual(newSpecReporter.failedSpecs, {});
+						});
+
+						it('should reset currentSuite arrays', function () {
+							proclaim.equal(newSpecReporter.currentSuite.length, 0);
+						});
+
+						it('should add error message to the errors array', function () {
+							proclaim.deepEqual(errors, [
+								colors.white('Test Browser failed specs:'),
+								colors.white('test/add.test.js') + ' suite name > description of test',
+								colors.white('Test Browser errored with:') + ' ' + colors.red('log'),
+								'1 tests failed across 1 browsers.'
+							]);
+						});
+
+						it('should be idempotent', () => {
+							newSpecReporter.currentSuite.push(failedSpec.suite);
+							newSpecReporter.failedSpecs = {
+								[browser.id]: [failedSpec]
+							};
+							newSpecReporter.onRunComplete([browser], {
+								failed: 1
+							});
+
+							proclaim.deepEqual(errors, [
+								colors.white('Test Browser failed specs:'),
+								colors.white('test/add.test.js') + ' suite name > description of test',
+								colors.white('Test Browser errored with:') + ' ' + colors.red('log'),
+								'1 tests failed across 1 browsers.'
+							]);
+						});
+					});
+				});
+			});
+
+			describe('onSpecComplete', function () {
+				let newSpecReporter;
+				let browser;
+				let failedResult;
+				let passedResult;
+
+				beforeEach(() => {
+					browser = {
+						name: 'Test Browser',
+						id: 'testValue'
+					};
+					failedResult = {
+						suite: ['suite name'],
+						description: 'description of test',
+						log: ['log message'],
+						success : false
+					};
+
+					passedResult = {
+						suite: ['suite name'],
+						description: 'description of test',
+						log: ['log message'],
+						success : true
+					};
+					newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
+				});
+
+				describe('no failed specs', () => {
+					it('should not anything to failedSpecs ', function () {
+						newSpecReporter.onSpecComplete(browser, passedResult);
+						proclaim.deepEqual(newSpecReporter.failedSpecs, {});
+					});
+				});
+
+				describe('failed specs', () => {
+					it('should add array of failed specs for browser to the failedSpecs property ', function () {
+						newSpecReporter.onSpecComplete(browser, failedResult);
+
+						const failedSpec = Object.create(null);
+						failedSpec[browser.id] = [failedResult];
+					});
+				});
+			});
+		});
+
+		context('running in a non-CI environment', function() {
+
+			beforeEach(function() {
+				mockery.enable({
+					useCleanCache: true,
+					warnOnReplace: false,
+					warnOnUnregistered: false
+				});
+				mockery.registerMock('is-ci', false);
+				mockery.registerAllowable('../../../lib/plugins/listr-karma.js');
+
+				const listrKarmaReporter = require('../../../lib/plugins/listr-karma.js')();
+				SpecReporter = listrKarmaReporter.reporter['reporter:listr'];
+				errors = listrKarmaReporter.errors;
+			});
+
+			describe('onRunComplete', function () {
+				describe('with no browsers', function () {
+					let newSpecReporter;
+
+					beforeEach(function () {
+						newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
+
+						newSpecReporter.currentSuite.push('suite name');
+						newSpecReporter.onRunComplete([], []);
 					});
 
 					it('should reset failedSpecs object', function () {
@@ -117,77 +227,139 @@ describe('SpecReporter', function () {
 						proclaim.equal(newSpecReporter.currentSuite.length, 0);
 					});
 
-					it('should add error message to the errors array', function () {
-						proclaim.deepEqual(errors, [
-							colors.white('Test Browser failed specs:'),
-							colors.white('suite name > description of test'),
-							colors.red('log\t'),
-							colors.red('message\t'),
-							'1 tests failed across 1 browsers.'
-						]);
+					it('should not add anything to the errors array', function () {
+						proclaim.equal(errors.length, 0);
 					});
+				});
 
-					it('should be idempotent', () => {
-						newSpecReporter.currentSuite.push(failedSpec.suite);
-						newSpecReporter.failedSpecs = {
-							[browser.id]: [failedSpec]
-						};
-						newSpecReporter.onRunComplete([browser], {
-							failed: 1
+				describe('with browsers', function () {
+					describe('and there are no failures', function () {
+						let newSpecReporter;
+
+						beforeEach(function () {
+							newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
+							newSpecReporter.onRunComplete(['testValue'], {
+								failed: 0
+							});
 						});
 
-						proclaim.deepEqual(errors, [
-							colors.white('Test Browser failed specs:'),
-							colors.white('suite name > description of test'),
-							colors.red('log\t'),
-							colors.red('message\t'),
-							'1 tests failed across 1 browsers.'
-						]);
+						it('should reset failedSpecs object', function () {
+							proclaim.deepEqual(newSpecReporter.failedSpecs, {});
+						});
+
+						it('should reset currentSuite arrays', function () {
+							proclaim.equal(newSpecReporter.currentSuite.length, 0);
+						});
+
+						it('should not add anything to the errors array', function () {
+							proclaim.equal(errors.length, 0);
+						});
+					});
+
+					describe('and there are failures', function () {
+						let newSpecReporter;
+						let browser;
+						let failedSpec;
+						beforeEach(function () {
+							browser = {
+								name: 'Test Browser',
+								id: 'testValue'
+							};
+							failedSpec = {
+								suite: ['suite name'],
+								description: 'description of test',
+								log: ['log', 'test/add.test.js']
+							};
+							newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
+							newSpecReporter.currentSuite.push(failedSpec.suite);
+							newSpecReporter.failedSpecs = {
+								[browser.id]: [failedSpec]
+							};
+							newSpecReporter.onRunComplete([browser], {
+								failed: 1
+							});
+						});
+
+						it('should reset failedSpecs object', function () {
+							proclaim.deepEqual(newSpecReporter.failedSpecs, {});
+						});
+
+						it('should reset currentSuite arrays', function () {
+							proclaim.equal(newSpecReporter.currentSuite.length, 0);
+						});
+
+						it('should add error message to the errors array', function () {
+							proclaim.deepEqual(errors, [
+								colors.white('Test Browser failed specs:'),
+								colors.white('suite name > description of test'),
+								colors.red('log\t'),
+								colors.red('test/add.test.js\t'),
+								'1 tests failed across 1 browsers.'
+							]);
+						});
+
+						it('should be idempotent', () => {
+							newSpecReporter.currentSuite.push(failedSpec.suite);
+							newSpecReporter.failedSpecs = {
+								[browser.id]: [failedSpec]
+							};
+							newSpecReporter.onRunComplete([browser], {
+								failed: 1
+							});
+
+							proclaim.deepEqual(errors, [
+								colors.white('Test Browser failed specs:'),
+								colors.white('suite name > description of test'),
+								colors.red('log\t'),
+								colors.red('test/add.test.js\t'),
+								'1 tests failed across 1 browsers.'
+							]);
+						});
 					});
 				});
 			});
-		});
 
-		describe('onSpecComplete', function () {
-			let newSpecReporter;
-			let browser;
-			let failedResult;
-			let passedResult;
+			describe('onSpecComplete', function () {
+				let newSpecReporter;
+				let browser;
+				let failedResult;
+				let passedResult;
 
-			beforeEach(() => {
-				browser = {
-					name: 'Test Browser',
-					id: 'testValue'
-				};
-				failedResult = {
-					suite: ['suite name'],
-					description: 'description of test',
-					log: ['log message'],
-					success : false
-				};
+				beforeEach(() => {
+					browser = {
+						name: 'Test Browser',
+						id: 'testValue'
+					};
+					failedResult = {
+						suite: ['suite name'],
+						description: 'description of test',
+						log: ['log message'],
+						success : false
+					};
 
-				passedResult = {
-					suite: ['suite name'],
-					description: 'description of test',
-					log: ['log message'],
-					success : true
-				};
-				newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
-			});
-
-			describe('no failed specs', () => {
-				it('should not anything to failedSpecs ', function () {
-					newSpecReporter.onSpecComplete(browser, passedResult);
-					proclaim.deepEqual(newSpecReporter.failedSpecs, {});
+					passedResult = {
+						suite: ['suite name'],
+						description: 'description of test',
+						log: ['log message'],
+						success : true
+					};
+					newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
 				});
-			});
 
-			describe('failed specs', () => {
-				it('should add array of failed specs for browser to the failedSpecs property ', function () {
-					newSpecReporter.onSpecComplete(browser, failedResult);
+				describe('no failed specs', () => {
+					it('should not anything to failedSpecs ', function () {
+						newSpecReporter.onSpecComplete(browser, passedResult);
+						proclaim.deepEqual(newSpecReporter.failedSpecs, {});
+					});
+				});
 
-					const failedSpec = Object.create(null);
-					failedSpec[browser.id] = [failedResult];
+				describe('failed specs', () => {
+					it('should add array of failed specs for browser to the failedSpecs property ', function () {
+						newSpecReporter.onSpecComplete(browser, failedResult);
+
+						const failedSpec = Object.create(null);
+						failedSpec[browser.id] = [failedResult];
+					});
 				});
 			});
 		});

--- a/test/unit/plugins/listr-karma.test.js
+++ b/test/unit/plugins/listr-karma.test.js
@@ -106,8 +106,8 @@ describe('SpecReporter', function () {
 						proclaim.deepEqual(errors, [
 							colors.white('Test Browser failed specs:'),
 							colors.white('suite name > description of test'),
-							colors.red('log message\t'),
-							'',
+							colors.red('log\t'),
+							colors.red('message\t'),
 							'1 tests failed across 1 browsers.'
 						]);
 					});
@@ -124,8 +124,8 @@ describe('SpecReporter', function () {
 						proclaim.deepEqual(errors, [
 							colors.white('Test Browser failed specs:'),
 							colors.white('suite name > description of test'),
-							colors.red('log message\t'),
-							'',
+							colors.red('log\t'),
+							colors.red('message\t'),
 							'1 tests failed across 1 browsers.'
 						]);
 					});

--- a/test/unit/plugins/listr-karma.test.js
+++ b/test/unit/plugins/listr-karma.test.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const mockery = require('mockery');
 const colors = require('colors/safe');
 const proclaim = require('proclaim');
 
@@ -15,10 +16,24 @@ describe('SpecReporter', function () {
 	let SpecReporter;
 	let errors;
 
-	beforeEach(() => {
+	beforeEach(function() {
+		mockery.enable({
+			useCleanCache: true,
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		});
+		mockery.registerMock('is-ci', false);
+		mockery.registerAllowable('../../../lib/plugins/listr-karma.js');
+
 		const listrKarmaReporter = require('../../../lib/plugins/listr-karma.js')();
 		SpecReporter = listrKarmaReporter.reporter['reporter:listr'];
 		errors = listrKarmaReporter.errors;
+	});
+
+	afterEach(() => {
+		mockery.resetCache();
+		mockery.deregisterAll();
+		mockery.disable();
 	});
 
 	describe('functionality', function () {

--- a/test/unit/tasks/pa11y.test.js
+++ b/test/unit/tasks/pa11y.test.js
@@ -55,7 +55,7 @@ describe('Test task', function() {
 
 		describe('task', () => {
 			it('should run pa11y correctly', function () {
-				this.timeout(10000);
+				this.timeout(30000);
 				return pa11y().task()
 					.catch(function (results) {
 						proclaim.isInstanceOf(results, Error);


### PR DESCRIPTION
problem matchers are used to capture errors from the CI output and put the errors as comments on the lines which correspond to the error.

Here is what the CI reporter looks like when tests fail.

```
[17:53:15] Completed tests on HeadlessChrome 83.0.4103 (Mac OS X 10.15.4) in 20.761 seconds. Ran 102 tests. 95 tests successful. 7 tests failed. Failed Karma tests: 

    HeadlessChrome 83.0.4103 (Mac OS X 10.15.4) failed specs:

    /Users/jake.champion/Code/repo-data-cli/repos/o-table/test/BaseTable.test.js:1812:15 BaseTable > addSortButtons > adds buttons in the table column headers

    HeadlessChrome 83.0.4103 (Mac OS X 10.15.4) errored with: AssertionError: Expected 5 buttons, 1 within each of the 5 column headers.

    /Users/jake.champion/Code/repo-data-cli/repos/o-table/test/BaseTable.test.js:1861:15 BaseTable > addSortButtons > does not add sort button to column header with attribute "data-o-table-heading-disable-sort"

    HeadlessChrome 83.0.4103 (Mac OS X 10.15.4) errored with: AssertionError: Found a sort button within a column heading with sort disabled.

    /Users/jake.champion/Code/repo-data-cli/repos/o-table/test/BaseTable.test.js:1896:15 BaseTable > addSortButtons > buttons toggle column sort with header button click (ascending first)

    HeadlessChrome 83.0.4103 (Mac OS X 10.15.4) errored with: AssertionError: Expected the table to be sorted "ascending" on first click of the header button. [failed]
```