### PR TITLE
Ignore some axe rules when running pa11y

### DIFF
--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -12,6 +12,13 @@ const pa11yTest = async function (config) {
 
 	// ignoring the href="#" error
 	const ignore = ['WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID'];
+	// pa11y demos are for pa11y only and may include multiple versions
+	// of a landmark component like o-footer
+	ignore.push('landmark-one-main');
+	ignore.push('landmark-no-duplicate-contentinfo');
+	ignore.push('landmark-unique');
+	// pa11y demos are for pa11y only and do not have a heading
+	ignore.push('page-has-heading-one');
 
 	// Run the Pa11y tests
 	const results = await pa11y(src, {


### PR DESCRIPTION
Axe finds issues our previous runner did not. This includes issues
we expect to see in pa11y demos. For example multiple footer
landmarks are ok when testing multiple variants of `o-footer`
e.g. https://github.com/Financial-Times/o-footer/pull/141