### PR TITLE
Only add karma annotations when we know which file to add them to

### DIFF
--- a/lib/plugins/listr-karma.js
+++ b/lib/plugins/listr-karma.js
@@ -37,9 +37,11 @@ module.exports = function () {
 							errors.push(colors.red(error.join('\n')));
 
 							if (isCI) {
-								const error = value.log.map(log => formatError(log, '\t')).join('\n').split('\n');
-								const message = error.filter(log => log.trim().length).shift().trim();
-								const [file, line, column] = error.pop().trim().replace('at ', '').split(':');
+								const error = value.log.map(log => formatError(log, '\t')).join('\n').split('\n').filter(log => log.trim().length);
+								const message = error.shift().trim();
+								// eslint-disable-next-line prefer-const
+								let [file, line, column] = error.pop().trim().replace('at ', '').split(':');
+								column = Number.parseInt(column, 10);
 								const fullTestDescription = value.suite.map((suite) => suite + ' > ').join('') + value.description;
 
 								const errorMessage = fullTestDescription + '\n' + browser.name + ' errored with: ' + message;

--- a/lib/plugins/listr-karma.js
+++ b/lib/plugins/listr-karma.js
@@ -39,14 +39,18 @@ module.exports = function () {
 							if (isCI) {
 								const error = value.log.map(log => formatError(log, '\t')).join('\n').split('\n').filter(log => log.trim().length);
 								const message = error.shift().trim();
-								// eslint-disable-next-line prefer-const
-								let [file, line, column] = error.pop().trim().replace('at ', '').split(':');
-								column = Number.parseInt(column, 10);
-								const fullTestDescription = value.suite.map((suite) => suite + ' > ').join('') + value.description;
+								// Errors which happen due to timeouts do not contain file information
+								// We do not add an annotation if we do not know which file to add it to.
+								if (error.length > 0) {
+									// eslint-disable-next-line prefer-const
+									let [file, line, column] = error.pop().trim().replace('at ', '').split(':');
+									column = Number.parseInt(column, 10);
+									const fullTestDescription = value.suite.map((suite) => suite + ' > ').join('') + value.description;
 
-								const errorMessage = fullTestDescription + '\n' + browser.name + ' errored with: ' + message;
-								const newLine = "%0A";
-								console.log(`::error file=${file},line=${line},col=${column}::${errorMessage.replace(/\n/g, newLine)}`);
+									const errorMessage = fullTestDescription + '\n' + browser.name + ' errored with: ' + message;
+									const newLine = "%0A";
+									console.log(`::error file=${file},line=${line},col=${column}::${errorMessage.replace(/\n/g, newLine)}`);
+								}
 							}
 
 						});

--- a/test/unit/plugins/listr-karma.test.js
+++ b/test/unit/plugins/listr-karma.test.js
@@ -83,7 +83,7 @@ describe('SpecReporter', function () {
 							failedSpec = {
 								suite: ['suite name'],
 								description: 'description of test',
-								log: ['2+2 doest not equal carrot', 'test/add.test.js:1:12']
+								log: ['2+2 does not equal carrot', 'test/add.test.js:1:12 <- test/add.test.js:1245:4325']
 							};
 							newSpecReporter = new SpecReporter[1](baseReporterDecorator, formatError);
 							newSpecReporter.currentSuite.push(failedSpec.suite);
@@ -99,7 +99,7 @@ describe('SpecReporter', function () {
 							proclaim.calledOnce(console.log);
 							proclaim.calledWithExactly(
 								console.log,
-								`::error file=test/add.test.js,line=1,col=12::suite name > description of test%0ATest Browser errored with: 2+2 doest not equal carrot`
+								`::error file=test/add.test.js,line=1,col=12::suite name > description of test%0ATest Browser errored with: 2+2 does not equal carrot`
 							);
 						});
 					});


### PR DESCRIPTION
When a test fails due to a timeout, we do not get given the file information for where the test originated from. Which means we can not add a good annotation to the pull-request