### PR TITLE
make pa11y ignore region rules

### DIFF
--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -18,6 +18,8 @@ const pa11yTest = async function (config) {
 	ignore.push('landmark-one-main');
 	ignore.push('landmark-no-duplicate-contentinfo');
 	ignore.push('landmark-unique');
+	// disable https://dequeuniversity.com/rules/axe/3.5/region?application=axeAPI
+	ignore.push('region');
 	// pa11y demos are for pa11y only and do not have a heading
 	ignore.push('page-has-heading-one');
 


### PR DESCRIPTION
This change will stop all the pa11y failures we currently see which are for 
<img width="1387" alt="image" src="https://user-images.githubusercontent.com/1569131/84655469-e7191000-af08-11ea-9e6a-c809f6956a7b.png">
