### PR TITLE
Allow components to define custom `.eslintrc.js` configuration.

### DIFF
--- a/lib/tasks/verify-javascript.js
+++ b/lib/tasks/verify-javascript.js
@@ -17,6 +17,13 @@ async function lint (config) {
 		const gitignorePath = path.join(config.cwd, '/.gitignore');
 		const hasGitignore = await fs.exists(gitignorePath);
 		const ignorePatterns = hasGitignore ? gitignore(await fs.readFile(gitignorePath)) : ['bower_components/', 'node_modules/'];
+
+		// Get eslint config from the component directory,
+		// or use the default if it does not exist.
+		const eslintPath = path.join(config.cwd, '/.eslintrc.js');
+		const hasEslint = await fs.exists(eslintPath);
+		const overrideConfigFile = hasEslint ? eslintPath : null;
+
 		const eslint = new ESLint({
 			baseConfig: {
 				extends: ["origami-component"],
@@ -26,8 +33,8 @@ async function lint (config) {
 				},
 				ignorePatterns,
 			},
-			useEslintrc: false,
-			cwd: config.cwd
+			overrideConfigFile,
+			useEslintrc: false
 		});
 
 		const results = await eslint.lintFiles(['**/*.js']);

--- a/test/integration/verify/fixtures/js-custom-eslint/.eslintrc.js
+++ b/test/integration/verify/fixtures/js-custom-eslint/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+ "extends": "origami-component",
+ "rules": {
+  "indent": ["error", 1]
+ }
+};

--- a/test/integration/verify/fixtures/js-custom-eslint/main.js
+++ b/test/integration/verify/fixtures/js-custom-eslint/main.js
@@ -1,4 +1,4 @@
 // tab indent invalid with custom .eslintrcjs configuration
 export default {
- eg: 'This was indented with a tab'
+ eg: 'This was indented with a space, instead of the usual tab'
 };

--- a/test/integration/verify/fixtures/js-custom-eslint/main.js
+++ b/test/integration/verify/fixtures/js-custom-eslint/main.js
@@ -1,0 +1,4 @@
+// tab indent invalid with custom .eslintrcjs configuration
+export default {
+ eg: 'This was indented with a tab'
+};

--- a/test/integration/verify/verify.test.js
+++ b/test/integration/verify/verify.test.js
@@ -60,6 +60,27 @@ describe('obt verify', function () {
 			});
 		});
 
+		describe('component with custom .eslintrc.js configuration', function () {
+
+			beforeEach(function () {
+				// Change the current working directory to the folder which contains the project we are testing against.
+				// We are doing this to replicate how obt is used when executed inside a terminal.
+				process.chdir(path.join(__dirname, '/fixtures/js-custom-eslint'));
+			});
+
+			afterEach(function () {
+				// Change the current working directory back to the directory where you started running these tests from.
+				process.chdir(process.cwd());
+			});
+
+			it('should not error given conformance with custom rules', function () {
+				return obtBinPath()
+					.then(obt => {
+						return execa(obt, ['verify']);
+					});
+			});
+		});
+
 		describe('component with valid ES5 js', function () {
 
 			beforeEach(function () {


### PR DESCRIPTION
As per the Origami specification:
https://github.com/Financial-Times/origami-website/blame/49e27d162ca28b212512e128d7987d9a58ee38b7/_specification-v1/javascript.md#L24