### PR TITLE
Test on 12.x and 14.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
-name: Test
+name: Test with node LTS and current
 on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
because [engines](https://github.com/Financial-Times/origami-build-tools/blob/master/package.json#L11) says we support 12+