### PR TITLE
use our version of create-origami-component

### DIFF
--- a/lib/tasks/init.js
+++ b/lib/tasks/init.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {run} = require('../helpers/command-line');
+
 module.exports = function () {
-	return run('npm', ['init', 'origami-component']);
+	return run('node', [require.resolve('create-origami-component')]);
 };


### PR DESCRIPTION
closes #864

The previous version of `obt init` was using `npm init origami-component` so there was an invisible dependency.
now we depend on a version range explicitly so we can use that version.