### PR TITLE
Use component's local `.remarkrc.js`

### DIFF
--- a/lib/tasks/verify-readme.js
+++ b/lib/tasks/verify-readme.js
@@ -12,6 +12,7 @@ const remark = require("remark");
 const remarkLint = require("remark-lint");
 const origamiPreset = require("remark-preset-lint-origami-component");
 const report = require("vfile-reporter");
+const log = require('../helpers/log');
 
 async function origamiJson(config) {
 	// Error if there is no readme to verify.
@@ -60,7 +61,7 @@ async function origamiJson(config) {
 				);
 			});
 		} else {
-			throw new Error(
+			log.secondary(
 				"README.md errors: \n\n" +
 					report(result, {
 						color: false,

--- a/lib/tasks/verify-readme.js
+++ b/lib/tasks/verify-readme.js
@@ -7,13 +7,20 @@ const {
 const path = require("path");
 const isCI = require("is-ci");
 const vfile = require("vfile");
+const fs = require('fs-extra');
 const remark = require("remark");
 const remarkLint = require("remark-lint");
 const origamiPreset = require("remark-preset-lint-origami-component");
 const report = require("vfile-reporter");
 
 async function origamiJson(config) {
+	// Error if there is no readme to verify.
 	const readmePath = path.join(config.cwd, "/README.md");
+	const hasReadme = await fs.exists(readmePath);
+	if (!hasReadme) {
+		throw new Error('Components require a README.md with documentation.');
+	}
+
 	const contents = await readFile(readmePath, {
 		encoding: "utf-8",
 	});
@@ -23,9 +30,19 @@ async function origamiJson(config) {
 		contents,
 	});
 
+	// Get remark config from the component directory,
+	// or use the default if it does not exist.
+	const remarkPath = path.join(config.cwd, '/.remarkrc.js');
+	const hasRemark = await fs.exists(remarkPath);
+	// Dynamically require component remark configuration.
+	// We allow a dynamic require as we trust the input:
+	// https://github.com/Financial-Times/origami-build-tools/issues/881
+	// eslint-disable-next-line import/no-dynamic-require
+	const remarkConfigFile = hasRemark ? require(remarkPath) : origamiPreset;
+
 	const result = await remark()
 		.use(remarkLint)
-		.use(origamiPreset)
+		.use(remarkConfigFile)
 		.process(readme);
 
 

--- a/lib/tasks/verify-readme.js
+++ b/lib/tasks/verify-readme.js
@@ -1,29 +1,29 @@
-"use strict";
+'use strict';
 
-const process = require("process");
+const process = require('process');
 const {
 	promises: {readFile},
-} = require("fs");
-const path = require("path");
-const isCI = require("is-ci");
-const vfile = require("vfile");
+} = require('fs');
+const path = require('path');
+const isCI = require('is-ci');
+const vfile = require('vfile');
 const fs = require('fs-extra');
-const remark = require("remark");
-const remarkLint = require("remark-lint");
-const origamiPreset = require("remark-preset-lint-origami-component");
-const report = require("vfile-reporter");
+const remark = require('remark');
+const remarkLint = require('remark-lint');
+const origamiPreset = require('remark-preset-lint-origami-component');
+const report = require('vfile-reporter');
 const log = require('../helpers/log');
 
 async function origamiJson(config) {
 	// Error if there is no readme to verify.
-	const readmePath = path.join(config.cwd, "/README.md");
+	const readmePath = path.join(config.cwd, '/README.md');
 	const hasReadme = await fs.exists(readmePath);
 	if (!hasReadme) {
 		throw new Error('Components require a README.md with documentation.');
 	}
 
 	const contents = await readFile(readmePath, {
-		encoding: "utf-8",
+		encoding: 'utf-8',
 	});
 
 	const readme = vfile({
@@ -50,22 +50,22 @@ async function origamiJson(config) {
 	if (result.messages.length) {
 		if (isCI) {
 			result.messages.forEach(issue => {
-				const newLine = "%0A";
+				const newLine = '%0A';
 				const message = issue.message.replace(/\n/g, newLine);
 				const line = issue.line;
 				const column = issue.column;
 				const code = issue.ruleId;
-				const severity = issue.severity === 2 ? "error" : "warning";
+				const severity = issue.severity === 2 ? 'error' : 'warning';
 				console.log(
 					`::${severity} file=README.md,line=${line},col=${column},code=${code},severity=${severity}::${message}`
 				);
 			});
 		} else {
 			log.secondary(
-				"README.md errors: \n\n" +
+				'README.md errors: \n\n' +
 					report(result, {
 						color: false,
-					}).replace(new RegExp(config.cwd, "gi"), ".")
+					}).replace(new RegExp(config.cwd, 'gi'), '.')
 			);
 		}
 	}
@@ -76,7 +76,7 @@ module.exports = cfg => {
 	config.cwd = config.cwd || process.cwd();
 
 	return {
-		title: "Verifying your component's README.md",
+		title: 'Verifying your component\'s README.md',
 		task: () => origamiJson(config),
 	};
 };

--- a/test/integration/verify/fixtures/js-bower-dependency/origami.json
+++ b/test/integration/verify/fixtures/js-bower-dependency/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/js-custom-eslint/origami.json
+++ b/test/integration/verify/fixtures/js-custom-eslint/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/js-es5/origami.json
+++ b/test/integration/verify/fixtures/js-es5/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/js-es6/origami.json
+++ b/test/integration/verify/fixtures/js-es6/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/js-es7/origami.json
+++ b/test/integration/verify/fixtures/js-es7/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/js-invalid/origami.json
+++ b/test/integration/verify/fixtures/js-invalid/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/js-npm-dependency/origami.json
+++ b/test/integration/verify/fixtures/js-npm-dependency/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/no-js-or-sass/origami.json
+++ b/test/integration/verify/fixtures/no-js-or-sass/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/no-readme/bower.json
+++ b/test/integration/verify/fixtures/no-readme/bower.json
@@ -1,0 +1,5 @@
+{
+	"name": "test-component",
+	"main": [],
+	"dependencies": {}
+}

--- a/test/integration/verify/fixtures/no-readme/main.js
+++ b/test/integration/verify/fixtures/no-readme/main.js
@@ -1,0 +1,2 @@
+const a = 10 ** 2;
+self.world = a;

--- a/test/integration/verify/fixtures/no-readme/main.scss
+++ b/test/integration/verify/fixtures/no-readme/main.scss
@@ -1,0 +1,12 @@
+@mixin oTestComponent() {
+	.o-test {
+		font-size: 18px;
+
+		&--error {
+			background-color: red;
+			color: white;
+		}
+	}
+}
+
+@include oTestComponent;

--- a/test/integration/verify/fixtures/no-readme/origami.json
+++ b/test/integration/verify/fixtures/no-readme/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/.remarkrc.js
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/.remarkrc.js
@@ -1,0 +1,1 @@
+module.exports.plugins = []

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/README.md
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/README.md
@@ -1,0 +1,7 @@
+# not-the-component-name
+
+test component
+
+## Licence
+
+MIT

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/bower.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/bower.json
@@ -1,0 +1,5 @@
+{
+	"name": "test-component",
+	"main": [],
+	"dependencies": {}
+}

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/main.js
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/main.js
@@ -1,0 +1,2 @@
+const a = 10 ** 2;
+self.world = a;

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/main.scss
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/main.scss
@@ -1,0 +1,12 @@
+@mixin oTestComponent() {
+	.o-test {
+		font-size: 18px;
+
+		&--error {
+			background-color: red;
+			color: white;
+		}
+	}
+}
+
+@include oTestComponent;

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/origami.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/readme-invalid/README.md
+++ b/test/integration/verify/fixtures/readme-invalid/README.md
@@ -1,0 +1,7 @@
+# not-the-component-name
+
+test component
+
+## Licence
+
+MIT

--- a/test/integration/verify/fixtures/readme-invalid/bower.json
+++ b/test/integration/verify/fixtures/readme-invalid/bower.json
@@ -1,0 +1,5 @@
+{
+	"name": "test-component",
+	"main": [],
+	"dependencies": {}
+}

--- a/test/integration/verify/fixtures/readme-invalid/main.js
+++ b/test/integration/verify/fixtures/readme-invalid/main.js
@@ -1,0 +1,2 @@
+const a = 10 ** 2;
+self.world = a;

--- a/test/integration/verify/fixtures/readme-invalid/main.scss
+++ b/test/integration/verify/fixtures/readme-invalid/main.scss
@@ -1,0 +1,12 @@
+@mixin oTestComponent() {
+	.o-test {
+		font-size: 18px;
+
+		&--error {
+			background-color: red;
+			color: white;
+		}
+	}
+}
+
+@include oTestComponent;

--- a/test/integration/verify/fixtures/readme-invalid/origami.json
+++ b/test/integration/verify/fixtures/readme-invalid/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/readme/README.md
+++ b/test/integration/verify/fixtures/readme/README.md
@@ -1,0 +1,7 @@
+# test-component
+
+test component
+
+## Licence
+
+MIT

--- a/test/integration/verify/fixtures/readme/bower.json
+++ b/test/integration/verify/fixtures/readme/bower.json
@@ -1,0 +1,5 @@
+{
+	"name": "test-component",
+	"main": [],
+	"dependencies": {}
+}

--- a/test/integration/verify/fixtures/readme/main.js
+++ b/test/integration/verify/fixtures/readme/main.js
@@ -1,0 +1,2 @@
+const a = 10 ** 2;
+self.world = a;

--- a/test/integration/verify/fixtures/readme/main.scss
+++ b/test/integration/verify/fixtures/readme/main.scss
@@ -1,0 +1,12 @@
+@mixin oTestComponent() {
+	.o-test {
+		font-size: 18px;
+
+		&--error {
+			background-color: red;
+			color: white;
+		}
+	}
+}
+
+@include oTestComponent;

--- a/test/integration/verify/fixtures/readme/origami.json
+++ b/test/integration/verify/fixtures/readme/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/sass-bower-dependency/origami.json
+++ b/test/integration/verify/fixtures/sass-bower-dependency/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/sass-custom-config/origami.json
+++ b/test/integration/verify/fixtures/sass-custom-config/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/sass-invalid/origami.json
+++ b/test/integration/verify/fixtures/sass-invalid/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/sass-npm-dependency/origami.json
+++ b/test/integration/verify/fixtures/sass-npm-dependency/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/fixtures/sass/origami.json
+++ b/test/integration/verify/fixtures/sass/origami.json
@@ -1,0 +1,22 @@
+{
+	"description": "for a fixture",
+	"keywords": [],
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"brands": [],
+	"support": "https://github.com/Financial-Times/o-example/issues",
+	"supportContact": {
+		"email": "origami.support@ft.com",
+		"slack": "financialtimes/#origami-support"
+	},
+	"supportStatus": "experimental",
+	"browserFeatures": {},
+	"demosDefaults": {
+
+
+		"documentClasses": "",
+		"dependencies": []
+	},
+	"demos": []
+}

--- a/test/integration/verify/verify.test.js
+++ b/test/integration/verify/verify.test.js
@@ -12,6 +12,84 @@ describe('obt verify', function () {
 
 	this.timeout(60 * 1000);
 
+	describe('readme', function () {
+		describe('component with no readme', function () {
+
+			beforeEach(function () {
+				// Change the current working directory to the folder which contains the project we are testing against.
+				// We are doing this to replicate how obt is used when executed inside a terminal.
+				process.chdir(path.join(__dirname, '/fixtures/no-readme'));
+			});
+
+			afterEach(function () {
+				// Change the current working directory back to the directory where you started running these tests from.
+				process.chdir(process.cwd());
+			});
+
+			it('should error', function () {
+				return obtBinPath()
+					.then(obt => {
+						return execa(obt, ['verify']);
+					})
+					.then(() => {
+						throw new Error('obt verify should error.');
+					}, output => {
+						// obt verify exited with a non-zero exit code, which is what we expected.
+						proclaim.include(output.stdout, 'Components require a README.md with documentation.');
+					});
+			});
+		});
+
+		describe('component with an invalid readme', function () {
+
+			beforeEach(function () {
+				// Change the current working directory to the folder which contains the project we are testing against.
+				// We are doing this to replicate how obt is used when executed inside a terminal.
+				process.chdir(path.join(__dirname, '/fixtures/readme-invalid'));
+			});
+
+			afterEach(function () {
+				// Change the current working directory back to the directory where you started running these tests from.
+				process.chdir(process.cwd());
+			});
+
+
+			it('should error', function () {
+				return obtBinPath()
+					.then(obt => {
+						return execa(obt, ['verify']);
+					})
+					.then(() => {
+						throw new Error('obt verify should error.');
+					}, output => {
+						// obt verify exited with a non-zero exit code, which is what we expected.
+						proclaim.include(output.stdout, 'expected "test-component", got "not-the-component-name"');
+					});
+			});
+		});
+
+		describe('component with custom .remarkrc.js configuration', function () {
+
+			beforeEach(function () {
+				// Change the current working directory to the folder which contains the project we are testing against.
+				// We are doing this to replicate how obt is used when executed inside a terminal.
+				process.chdir(path.join(__dirname, '/fixtures/readme-custom-remarkrc'));
+			});
+
+			afterEach(function () {
+				// Change the current working directory back to the directory where you started running these tests from.
+				process.chdir(process.cwd());
+			});
+
+			it('should not error given conformance with custom rules', function () {
+				return obtBinPath()
+					.then(obt => {
+						return execa(obt, ['verify']);
+					});
+			});
+		});
+	});
+
 	describe('js', function () {
 		describe('component with no js', function () {
 

--- a/test/integration/verify/verify.test.js
+++ b/test/integration/verify/verify.test.js
@@ -54,15 +54,12 @@ describe('obt verify', function () {
 			});
 
 
-			it('should error', function () {
+			it('should warn', function () {
 				return obtBinPath()
 					.then(obt => {
 						return execa(obt, ['verify']);
 					})
-					.then(() => {
-						throw new Error('obt verify should error.');
-					}, output => {
-						// obt verify exited with a non-zero exit code, which is what we expected.
+					.then(output => {
 						proclaim.include(output.stdout, 'expected "test-component", got "not-the-component-name"');
 					});
 			});


### PR DESCRIPTION
Falls back to default `.remarkrc.js` configuration if not found
within the component directory:
https://github.com/Financial-Times/origami-build-tools/issues/875

In a future major version an error will be thrown instead if
`.remarkrc.js` is not found within the component directory:
https://github.com/Financial-Times/origami-build-tools/issues/876

_Note: This commit also adds an `origami.json` to test fixtures,
as it is now required by `obt verify`._