### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/test/integration/demo/fixtures/multiple-demos/main.js
+++ b/test/integration/demo/fixtures/multiple-demos/main.js
@@ -1,4 +1,4 @@
-import oMultipleDemos from './src/js/o-multiple-demos';
+import oMultipleDemos from './src/js/o-multiple-demos.js';
 const constructAll = function () {
 	oMultipleDemos.init();
 	document.removeEventListener('o.DOMContentLoaded', constructAll);

--- a/test/unit/fixtures/o-test/main.js
+++ b/test/unit/fixtures/o-test/main.js
@@ -1,3 +1,3 @@
-import test from './src/js/test';
+import test from './src/js/test.js';
 test();
 


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing