### PR TITLE
Include the `CustomEvent` polyfill in all demos

### DIFF
--- a/lib/helpers/construct-polyfill-url.js
+++ b/lib/helpers/construct-polyfill-url.js
@@ -19,8 +19,13 @@ async function constructBrowserDeps() {
 	}));
 
 	const features = Array.from(new Set(requiredFeatures));
+	// Include the `CustomEvent` polyfill so that demos which include dev
+	// dependencies work in older browsers. This is because the Origami Build
+	// Service includes `o-autoinit` which requires the `CustomElement` polyfill.
+	// https://github.com/Financial-Times/origami-build-tools/issues/906
+	features.push('CustomEvent');
 	if (features.length > 0) {
-		return `https://polyfill.io/v3/polyfill.min.js?features=,${features.join(',')}&flags=gated&unknown=polyfill`;
+		return `https://polyfill.io/v3/polyfill.min.js?features=${features.join(',')}&flags=gated&unknown=polyfill`;
 	} else {
 		return 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill';
 	}

--- a/test/unit/helpers/construct-polyfill-url.test.js
+++ b/test/unit/helpers/construct-polyfill-url.test.js
@@ -64,7 +64,7 @@ describe('construct-polyfill-url', function() {
 			globby.resolves([]);
 			return constructPolyfillUrl()
 				.then(polyfillUrl => {
-					proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
+					proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=CustomEvent&flags=gated&unknown=polyfill');
 				});
 		});
 	});
@@ -77,7 +77,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=CustomEvent&flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -89,7 +89,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=CustomEvent&flags=gated&unknown=polyfill');
 					});
 			});
 		});
@@ -101,7 +101,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=,Array.prototype.every&flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.every,CustomEvent&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -112,7 +112,7 @@ describe('construct-polyfill-url', function() {
 
 				return constructPolyfillUrl()
 					.then(polyfillUrl => {
-						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=,Array.prototype.every,Array.prototype.some&flags=gated&unknown=polyfill');
+						proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.every,Array.prototype.some,CustomEvent&flags=gated&unknown=polyfill');
 					});
 			});
 
@@ -123,7 +123,7 @@ describe('construct-polyfill-url', function() {
 
 					return constructPolyfillUrl()
 						.then(polyfillUrl => {
-							proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill');
+							proclaim.equal(polyfillUrl, 'https://polyfill.io/v3/polyfill.min.js?features=CustomEvent&flags=gated&unknown=polyfill');
 						});
 				});
 			});


### PR DESCRIPTION
So demos with dev dependencies work in older browsers. This is because the
Origami Build Service includes `o-autoinit` which requires the `CustomElement`
polyfill.

This has come up because we stopped including the "default" set of polyfills
which included `CustomElement`.
https://github.com/Financial-Times/origami-build-tools/pull/623

We could solve this in a better way, issue here:
https://github.com/Financial-Times/origami-build-tools/issues/906