### PR TITLE
Add regenerator runtime to ensure async functions work when compiled to es5

### DIFF
--- a/config/karma.config.js
+++ b/config/karma.config.js
@@ -43,6 +43,7 @@ module.exports.getBaseKarmaConfig = function (opts = { ignoreBower: false }) {
 
 			// list of files / patterns to load in the browser
 			files: [
+				require.resolve('regenerator-runtime'),
 				'test/*.js',
 				'test/**/*.js',
 				'main.scss'
@@ -66,7 +67,7 @@ module.exports.getBaseKarmaConfig = function (opts = { ignoreBower: false }) {
 			// preprocess matching files before serving them to the browser
 			// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 			preprocessors: {
-				'test/**/*.js': ['scrumple', 'swc', 'sourcemap'],
+				'test/**/*.js': ['swc', 'scrumple', 'sourcemap'],
 				'main.scss': ['scss']
 			},
 			scssPreprocessor: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8554,6 +8554,11 @@
         "esprima": "~4.0.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"portfinder": "^1.0.26",
 		"postcss": "^7.0.27",
 		"proclaim": "^3.6.0",
+		"regenerator-runtime": "^0.13.7",
 		"remark": "^12.0.1",
 		"remark-lint": "^7.0.1",
 		"remark-preset-lint-origami-component": "^1.1.3",


### PR DESCRIPTION
Our compiler (swc) add `require('regenerator-runtime')` to it's output when compiling an async function. We need to add regenerator-runtime as a dependency to obt and include it in the bundle output for tests in order for them to run in older browsers such as IE11.