### PR TITLE
Pass through the ignoreBower flag to obt develop

### DIFF
--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -159,9 +159,17 @@ if (task && (argument === 'develop' || argument === 'dev')) {
 	startServer(port);
 	// build demos whenever changes are detected
 	let childProcess;
-	const devArguments = cli.flags.brand ?
-		['demo', '--brand', cli.flags.brand] :
-		['demo'];
+
+	const devArguments = ['demo'];
+
+	if (cli.flags.brand) {
+		devArguments.push('--brand', cli.flags.brand);
+	}
+
+	if (cli.flags.ignoreBower) {
+		devArguments.push('--ignore-bower');
+	}
+
 	chokidar.watch(cli.flags.cwd || process.cwd(), {
 		ignored: [
 			'node_modules',


### PR DESCRIPTION
So that it can work with a post-occ (or npm native :eyes:) origami component