### PR TITLE
do not call npm test from within obt test

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,9 @@
 # Migration Guides
 
+## Migrating from v10 to v11
+
+`obt test` no longer runs `npm test`, this is to allow `obt test` to be a command within the components `npm test` script.
+
 ## Migrating from v9 to v10
 The following `demo` command flags have been removed and replaced with the `develop` (`dev`) command:
 - Removed the `--watch` flag.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ Runs JavaScript and Sass tests.
 
 Checks Sass supports [silent and non-silent compilation modes](https://origami.ft.com/spec/v1/sass/#sass-silent-mode).
 If `pa11y.html` demo exists, confirms it is accessible using [Pa11y](http://pa11y.org/).
-If `package.json` contains a `test` script, confirms it exits with a 0 exit code.
 Runs tests using [Karma](https://karma-runner.github.io) defaulting to Chrome Stable, can be configured to use BrowserStack by using the `--browserstack` flag. You will need the environment variables `BROWSER_STACK_USERNAME` and `BROWSER_STACK_ACCESS_KEY` set. This will run the tests on the minimum version for enhanced experience based on the [FT Browser Support Policy[(https://docs.google.com/document/d/1mByh6sT8zI4XRyPKqWVsC2jUfXHZvhshS5SlHErWjXU).
 
 ## Migration Guides

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -1,16 +1,11 @@
 'use strict';
 
 module.exports = function (cfg) {
-	const commandLine = require('../helpers/command-line');
-	const files = require('../helpers/files');
 	const pa11y = require('./pa11y');
 	const karma = require('./karma');
 	const compilationTests = require('./test-sass-compilation');
 	const testSass = require('./test-sass');
 
-	const npmTest = function (config) {
-		return commandLine.run('npm', ['test'], config);
-	};
 
 	cfg = cfg || {};
 	const config = cfg.flags || {};
@@ -23,16 +18,6 @@ module.exports = function (cfg) {
 		[
 			compilationTests(config),
 			testSass(config),
-			{
-				title: 'Executing `npm test`',
-				task: () => npmTest(config),
-				skip: () => {
-					return files.getPackageJson(config.cwd)
-						.then(packageJson => {
-							return !(packageJson && packageJson.scripts && packageJson.scripts.test);
-						});
-				}
-			},
 			pa11y(config),
 			karma(config)
 		], {


### PR DESCRIPTION
by having `obt test` call `npm test` we are stopping our components from having `obt test` within their `npm test` script.

If we stop calling `npm test` from within `obt test` then we can can add `obt test` within each components `npm test` script, thereby making `npm install && npm test` work for our components.

I think I've worded this poorly, sorry everyone.


With the current obt, this would be an infinite loop:
```json
{
	"scripts": {
		"test": "obt test"
	}
}
```

If this pull-request is merged then the above configuration would work.