### PR TITLE
Require component lint configuration.

### DIFF
--- a/config/.stylelintrc.json
+++ b/config/.stylelintrc.json
@@ -1,3 +1,0 @@
-{
-   "extends": "stylelint-config-origami-component"
-}

--- a/lib/tasks/verify-javascript.js
+++ b/lib/tasks/verify-javascript.js
@@ -18,22 +18,19 @@ async function lint (config) {
 		const hasGitignore = await fs.exists(gitignorePath);
 		const ignorePatterns = hasGitignore ? gitignore(await fs.readFile(gitignorePath)) : ['bower_components/', 'node_modules/'];
 
-		// Get eslint config from the component directory,
-		// or use the default if it does not exist.
-		const eslintPath = path.join(config.cwd, '/.eslintrc.js');
+		// Get eslint config from the component directory.
+		const eslintFile = '.eslintrc.js';
+		const eslintPath = path.join(config.cwd, eslintFile);
 		const hasEslint = await fs.exists(eslintPath);
-		const overrideConfigFile = hasEslint ? eslintPath : null;
+		if (!hasEslint) {
+			throw new Error(`Could not lint JavaScript. The component is missing lint configuration "${eslintFile}".`);
+		}
 
 		const eslint = new ESLint({
 			baseConfig: {
-				extends: ["origami-component"],
-				env: {
-					'browser': true,
-					'mocha': true
-				},
 				ignorePatterns,
 			},
-			overrideConfigFile,
+			overrideConfigFile: eslintPath,
 			useEslintrc: false
 		});
 

--- a/lib/tasks/verify-readme.js
+++ b/lib/tasks/verify-readme.js
@@ -10,7 +10,6 @@ const vfile = require('vfile');
 const fs = require('fs-extra');
 const remark = require('remark');
 const remarkLint = require('remark-lint');
-const origamiPreset = require('remark-preset-lint-origami-component');
 const report = require('vfile-reporter');
 const log = require('../helpers/log');
 
@@ -37,13 +36,17 @@ async function origamiJson(config) {
 
 	// Get remark config from the component directory,
 	// or use the default if it does not exist.
-	const remarkPath = path.join(config.cwd, '/.remarkrc.js');
+	const remarkFile = '.remarkrc.js';
+	const remarkPath = path.join(config.cwd, remarkFile);
 	const hasRemark = await fs.exists(remarkPath);
+	if (!hasRemark) {
+		throw new Error(`Could not lint the README. The component is missing lint configuration "${remarkFile}".`);
+	}
 	// Dynamically require component remark configuration.
 	// We allow a dynamic require as we trust the input:
 	// https://github.com/Financial-Times/origami-build-tools/issues/881
 	// eslint-disable-next-line import/no-dynamic-require
-	const remarkConfigFile = hasRemark ? require(remarkPath) : origamiPreset;
+	const remarkConfigFile = require(remarkPath);
 
 	const result = await remark()
 		.use(remarkLint)

--- a/lib/tasks/verify-sass.js
+++ b/lib/tasks/verify-sass.js
@@ -9,8 +9,6 @@ const deglob = denodeify(require('deglob'));
 const fs = require('fs-extra');
 const isCI = require('is-ci');
 
-const defaultStylelintPath = path.join(__dirname, '/../../config/.stylelintrc.json');
-
 async function sassLint(config) {
 	const hasScss = await projectHasScssFiles(config);
 
@@ -27,15 +25,17 @@ async function sassLint(config) {
 			'!node_modules/**'
 		].concat(gitIgnorePatterns);
 
-		// Get stylelint config from the component directory,
-		// or use the default if it does not exist.
-		const stylelintPath = path.join(config.cwd, '/.stylelintrc.js');
+		// Get stylelint config from the component directory.
+		const stylelintFile = '.stylelintrc.js';
+		const stylelintPath = path.join(config.cwd, stylelintFile);
 		const hasStylelint = await fs.exists(stylelintPath);
-		const configPath = hasStylelint ? stylelintPath : defaultStylelintPath;
+		if (!hasStylelint) {
+			throw new Error(`Could not lint Sass. The component is missing lint configuration "${stylelintFile}".`);
+		}
 
 		const result = await lint.lint({
 			files: [path.join(config.cwd, '**/*.scss'), ...ignorePatterns],
-			configFile: configPath,
+			configFile: stylelintPath,
 			configBasedir: path.join(__dirname, '../../'),
 			formatter: "compact"
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -993,14 +993,6 @@
         "@types/node": "*"
       }
     },
-    "@types/mdast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-      "requires": {
-        "@types/unist": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1728,11 +1720,6 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
-    },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bower": {
       "version": "1.8.8",
@@ -2611,11 +2598,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "css-selector-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
-      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -4128,21 +4110,6 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "github-slugger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
-      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
-      "requires": {
-        "emoji-regex": ">=6.0.0 <=6.1.1"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
-        }
       }
     },
     "glob": {
@@ -5662,11 +5629,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
       "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
     },
-    "lodash.iteratee": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz",
-      "integrity": "sha1-vkF32yiajMw8CZDx2ya1si/BVUw="
-    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -5943,24 +5905,6 @@
       "requires": {
         "unist-util-visit": "^2.0.0"
       }
-    },
-    "mdast-util-heading-range": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-heading-range/-/mdast-util-heading-range-2.1.4.tgz",
-      "integrity": "sha512-ea+YwoFQZiwSf5TLlk9qtKb0AUKsn1oCzdskn2SXsHylA/vW9ZxmMzuCNsFi9siWW1WS1/JSOipX2brUwisIHA==",
-      "requires": {
-        "mdast-util-to-string": "^1.0.0"
-      }
-    },
-    "mdast-util-heading-style": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/mdast-util-heading-style/-/mdast-util-heading-style-1.0.6.tgz",
-      "integrity": "sha512-8ZuuegRqS0KESgjAGW8zTx4tJ3VNIiIaGFNEzFpRSAQBavVc7AvOo9I4g3crcZBfYisHs4seYh0rAVimO6HyOw=="
-    },
-    "mdast-util-to-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
-      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -6982,11 +6926,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
-    "not": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
-      "integrity": "sha1-yWkcF0bFXc++VMvYvU/wQbwrUZ0="
-    },
     "npm-prepublish": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/npm-prepublish/-/npm-prepublish-1.2.3.tgz",
@@ -7041,14 +6980,6 @@
         "console-control-strings": "~1.1.0",
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
-      }
-    },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "requires": {
-        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -7776,11 +7707,6 @@
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
       "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
       "dev": true
-    },
-    "pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -8545,299 +8471,6 @@
         "remark-message-control": "^6.0.0"
       }
     },
-    "remark-lint-blockquote-indentation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-2.0.1.tgz",
-      "integrity": "sha512-uJ9az/Ms9AapnkWpLSCJfawBfnBI2Tn1yUsPNqIFv6YM98ymetItUMyP6ng9NFPqDvTQBbiarulkgoEo0wcafQ==",
-      "requires": {
-        "mdast-util-to-string": "^1.0.2",
-        "pluralize": "^8.0.0",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-checkbox-character-style": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-2.0.1.tgz",
-      "integrity": "sha512-ANs1HaNOEYmc+O9Xyew7HRA48VXPnk7VLM76fLEf6bifXZU+VAJe+a6cmS+ohTSVSTjkMDl9dnbqiWQRE1U4zg==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0",
-        "vfile-location": "^3.0.0"
-      }
-    },
-    "remark-lint-code-block-style": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-code-block-style/-/remark-lint-code-block-style-2.0.1.tgz",
-      "integrity": "sha512-eRhmnColmSxJhO61GHZkvO67SpHDshVxs2j3+Zoc5Y1a4zQT2133ZAij04XKaBFfsVLjhbY/+YOWxgvtjx2nmA==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-emphasis-marker": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-2.0.1.tgz",
-      "integrity": "sha512-7mpbAUrSnHiWRyGkbXRL5kfSKY9Cs8cdob7Fw+Z02/pufXMF4yRWaegJ5NTUu1RE+SKlF44wtWWjvcIoyY6/aw==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-fenced-code-marker": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-2.0.1.tgz",
-      "integrity": "sha512-lujpjm04enn3ma6lITlttadld6eQ1OWAEcT3qZzvFHp+zPraC0yr0eXlvtDN/0UH8mrln/QmGiZp3i8IdbucZg==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-final-newline": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/remark-lint-final-newline/-/remark-lint-final-newline-1.0.5.tgz",
-      "integrity": "sha512-rfLlW8+Fz2dqnaEgU4JwLA55CQF1T4mfSs/GwkkeUCGPenvEYwSkCN2KO2Gr1dy8qPoOdTFE1rSufLjmeTW5HA==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0"
-      }
-    },
-    "remark-lint-hard-break-spaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-hard-break-spaces/-/remark-lint-hard-break-spaces-2.0.1.tgz",
-      "integrity": "sha512-Qfn/BMQFamHhtbfLrL8Co/dbYJFLRL4PGVXZ5wumkUO5f9FkZC2RsV+MD9lisvGTkJK0ZEJrVVeaPbUIFM0OAw==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-heading-style": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-2.0.1.tgz",
-      "integrity": "sha512-IrFLNs0M5Vbn9qg51AYhGUfzgLAcDOjh2hFGMz3mx664dV6zLcNZOPSdJBBJq3JQR4gKpoXcNwN1+FFaIATj+A==",
-      "requires": {
-        "mdast-util-heading-style": "^1.0.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-link-title-style": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-link-title-style/-/remark-lint-link-title-style-2.0.1.tgz",
-      "integrity": "sha512-+Q7Ew8qpOQzjqbDF6sUHmn9mKgje+m2Ho8Xz7cEnGIRaKJgtJzkn/dZqQM/az0gn3zaN6rOuwTwqw4EsT5EsIg==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0",
-        "vfile-location": "^3.0.0"
-      }
-    },
-    "remark-lint-list-item-bullet-indent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-2.0.1.tgz",
-      "integrity": "sha512-tozDt9LChG1CvYJnBQH/oh45vNcHYBvg79ogvV0f8MtE/K0CXsM8EpfQ6pImFUdHpBV1op6aF6zPMrB0AkRhcQ==",
-      "requires": {
-        "pluralize": "^8.0.0",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-list-item-content-indent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-list-item-content-indent/-/remark-lint-list-item-content-indent-2.0.1.tgz",
-      "integrity": "sha512-OzUMqavxyptAdG7vWvBSMc9mLW9ZlTjbW4XGayzczd3KIr6Uwp3NEFXKx6MLtYIM/vwBqMrPQUrObOC7A2uBpQ==",
-      "requires": {
-        "pluralize": "^8.0.0",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-list-item-indent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-list-item-indent/-/remark-lint-list-item-indent-2.0.1.tgz",
-      "integrity": "sha512-4IKbA9GA14Q9PzKSQI6KEHU/UGO36CSQEjaDIhmb9UOhyhuzz4vWhnSIsxyI73n9nl9GGRAMNUSGzr4pQUFwTA==",
-      "requires": {
-        "pluralize": "^8.0.0",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-auto-link-without-protocol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-auto-link-without-protocol/-/remark-lint-no-auto-link-without-protocol-2.0.1.tgz",
-      "integrity": "sha512-TFcXxzucsfBb/5uMqGF1rQA+WJJqm1ZlYQXyvJEXigEZ8EAxsxZGPb/gOQARHl/y0vymAuYxMTaChavPKaBqpQ==",
-      "requires": {
-        "mdast-util-to-string": "^1.0.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-blockquote-without-marker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-3.0.1.tgz",
-      "integrity": "sha512-sM953+u0zN90SGd2V5hWcFbacbpaROUslS5Q5F7/aa66/2rAwh6zVnrXc4pf7fFOpj7I9Xa8Aw+uB+3RJWwdrQ==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0",
-        "vfile-location": "^3.0.0"
-      }
-    },
-    "remark-lint-no-duplicate-definitions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-2.0.1.tgz",
-      "integrity": "sha512-XL22benJZB01m+aOse91nsu1IMFqeWJWme9QvoJuxIcBROO1BG1VoqLOkwNcawE/M/0CkvTo5rfx0eMlcnXOIw==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-heading-content-indent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-2.0.1.tgz",
-      "integrity": "sha512-Jp0zCykGwg13z7XU4VuoFK7DN8bVZ1u3Oqu3hqECsH6LMASb0tW4zcTIc985kcVo3OQTRyb6KLQXL2ltOvppKA==",
-      "requires": {
-        "mdast-util-heading-style": "^1.0.2",
-        "pluralize": "^8.0.0",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-inline-padding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-2.0.1.tgz",
-      "integrity": "sha512-a36UlPvRrLCgxjjG3YZA9VCDvLBcoBtGNyM04VeCPz+d9hHe+5Fs1C/jL+DRLCH7nff90jJ5C/9b8/LTwhjaWA==",
-      "requires": {
-        "mdast-util-to-string": "^1.0.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-literal-urls": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-literal-urls/-/remark-lint-no-literal-urls-2.0.1.tgz",
-      "integrity": "sha512-IDdKtWOMuKVQIlb1CnsgBoyoTcXU3LppelDFAIZePbRPySVHklTtuK57kacgU5grc7gPM04bZV96eliGrRU7Iw==",
-      "requires": {
-        "mdast-util-to-string": "^1.0.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-shortcut-reference-image": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-shortcut-reference-image/-/remark-lint-no-shortcut-reference-image-2.0.1.tgz",
-      "integrity": "sha512-2jcZBdnN6ecP7u87gkOVFrvICLXIU5OsdWbo160FvS/2v3qqqwF2e/n/e7D9Jd+KTq1mR1gEVVuTqkWWuh3cig==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-shortcut-reference-link": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-shortcut-reference-link/-/remark-lint-no-shortcut-reference-link-2.0.1.tgz",
-      "integrity": "sha512-pTZbslG412rrwwGQkIboA8wpBvcjmGFmvugIA+UQR+GfFysKtJ5OZMPGJ98/9CYWjw9Z5m0/EktplZ5TjFjqwA==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-undefined-references": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-2.0.1.tgz",
-      "integrity": "sha512-tXM2ctFnduC3QcskrIePUajcjtNtBmo2dvlj4aoQJtQy09Soav/rYngb8u/SgERc6Irdmm5s55UAwR9CcSrzVg==",
-      "requires": {
-        "collapse-white-space": "^1.0.4",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-no-unused-definitions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-2.0.1.tgz",
-      "integrity": "sha512-+BMc0BOjc364SvKYLkspmxDch8OaKPbnUGgQBvK0Bmlwy42baR4C9zhwAWBxm0SBy5Z4AyM4G4jKpLXPH40Oxg==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-ordered-list-marker-style": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-2.0.1.tgz",
-      "integrity": "sha512-Cnpw1Dn9CHn+wBjlyf4qhPciiJroFOEGmyfX008sQ8uGoPZsoBVIJx76usnHklojSONbpjEDcJCjnOvfAcWW1A==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-rule-style": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-rule-style/-/remark-lint-rule-style-2.0.1.tgz",
-      "integrity": "sha512-hz4Ff9UdlYmtO6Czz99WJavCjqCer7Cav4VopXt+yVIikObw96G5bAuLYcVS7hvMUGqC9ZuM02/Y/iq9n8pkAg==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-strong-marker": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-strong-marker/-/remark-lint-strong-marker-2.0.1.tgz",
-      "integrity": "sha512-8X2IsW1jZ5FmW9PLfQjkL0OVy/J3xdXLcZrG1GTeQKQ91BrPFyEZqUM2oM6Y4S6LGtxWer+neZkPZNroZoRPBQ==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
-    "remark-lint-table-cell-padding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-2.0.1.tgz",
-      "integrity": "sha512-vytUq4O1cg9UBXyeduANqpVqlbZpEtpXe/hYdvAObWgp1Jr7l74Zcvm+pn/ouaCuAsrxDVWeTa5Mg3V4OByw4g==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
     "remark-message-control": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/remark-message-control/-/remark-message-control-6.0.0.tgz",
@@ -8868,51 +8501,6 @@
         "unist-util-remove-position": "^2.0.0",
         "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
-      }
-    },
-    "remark-preset-lint-origami-component": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-origami-component/-/remark-preset-lint-origami-component-1.1.3.tgz",
-      "integrity": "sha512-5U0BlhJSiKcI0tmd5zvwHzWxt+VkMLDpcyXOpNr2LFuQuylWjFpIZyI8u78pbaLmKqh96qAmHNhVFQbEirIjsg==",
-      "requires": {
-        "@types/mdast": "^3.0.3",
-        "@types/unist": "^2.0.3",
-        "github-slugger": "^1.3.0",
-        "mdast-util-heading-range": "^2.1.4",
-        "remark-lint": "^7.0.0",
-        "remark-lint-blockquote-indentation": "^2.0.0",
-        "remark-lint-checkbox-character-style": "^2.0.0",
-        "remark-lint-code-block-style": "^2.0.0",
-        "remark-lint-emphasis-marker": "^2.0.0",
-        "remark-lint-fenced-code-marker": "^2.0.0",
-        "remark-lint-final-newline": "^1.0.4",
-        "remark-lint-hard-break-spaces": "^2.0.0",
-        "remark-lint-heading-style": "^2.0.0",
-        "remark-lint-link-title-style": "^2.0.0",
-        "remark-lint-list-item-bullet-indent": "^2.0.0",
-        "remark-lint-list-item-content-indent": "^2.0.0",
-        "remark-lint-list-item-indent": "^2.0.0",
-        "remark-lint-no-auto-link-without-protocol": "^2.0.0",
-        "remark-lint-no-blockquote-without-marker": "^3.0.0",
-        "remark-lint-no-duplicate-definitions": "^2.0.0",
-        "remark-lint-no-heading-content-indent": "^2.0.0",
-        "remark-lint-no-inline-padding": "^2.0.0",
-        "remark-lint-no-literal-urls": "^2.0.0",
-        "remark-lint-no-shortcut-reference-image": "^2.0.0",
-        "remark-lint-no-shortcut-reference-link": "^2.0.0",
-        "remark-lint-no-undefined-references": "^2.0.0",
-        "remark-lint-no-unused-definitions": "^2.0.0",
-        "remark-lint-ordered-list-marker-style": "^2.0.0",
-        "remark-lint-rule-style": "^2.0.0",
-        "remark-lint-strong-marker": "^2.0.0",
-        "remark-lint-table-cell-padding": "^2.0.0",
-        "unified-lint-rule": "^1.0.5",
-        "unist-util-find": "^1.0.1",
-        "unist-util-find-all-after": "^3.0.1",
-        "unist-util-find-all-before": "^2.0.5",
-        "unist-util-find-all-between": "^2.0.0",
-        "unist-util-select": "^3.0.1",
-        "unist-util-visit": "^2.0.2"
       }
     },
     "remark-stringify": {
@@ -9468,11 +9056,6 @@
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
-    },
-    "sliced": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "smart-buffer": {
       "version": "4.1.0",
@@ -11549,14 +11132,6 @@
         }
       }
     },
-    "unified-lint-rule": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-1.0.6.tgz",
-      "integrity": "sha512-YPK15YBFwnsVorDFG/u0cVVQN5G2a3V8zv5/N6KN3TCG+ajKtaALcy7u14DCSrJI+gZeyYquFL9cioJXOGXSvg==",
-      "requires": {
-        "wrapped": "^1.0.1"
-      }
-    },
     "unified-message-control": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/unified-message-control/-/unified-message-control-3.0.1.tgz",
@@ -11590,184 +11165,10 @@
         "uid2": "0.0.3"
       }
     },
-    "unist-util-find": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.1.tgz",
-      "integrity": "sha1-EGK7tpKMepfGrcibU3RdTEbCIqI=",
-      "requires": {
-        "lodash.iteratee": "^4.5.0",
-        "remark": "^5.0.1",
-        "unist-util-visit": "^1.1.0"
-      },
-      "dependencies": {
-        "longest-streak": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
-          "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU="
-        },
-        "markdown-table": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
-          "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
-        },
-        "parse-entities": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-          "requires": {
-            "character-entities": "^1.0.0",
-            "character-entities-legacy": "^1.0.0",
-            "character-reference-invalid": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-hexadecimal": "^1.0.0"
-          }
-        },
-        "remark": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/remark/-/remark-5.1.0.tgz",
-          "integrity": "sha1-y0Y709vLS5l5STXu4c9x16jjBow=",
-          "requires": {
-            "remark-parse": "^1.1.0",
-            "remark-stringify": "^1.1.0",
-            "unified": "^4.1.1"
-          }
-        },
-        "remark-parse": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-1.1.0.tgz",
-          "integrity": "sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=",
-          "requires": {
-            "collapse-white-space": "^1.0.0",
-            "extend": "^3.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0"
-          }
-        },
-        "remark-stringify": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-1.1.0.tgz",
-          "integrity": "sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=",
-          "requires": {
-            "ccount": "^1.0.0",
-            "extend": "^3.0.0",
-            "longest-streak": "^1.0.0",
-            "markdown-table": "^0.4.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "stringify-entities": "^1.0.1",
-            "unherit": "^1.0.4"
-          }
-        },
-        "stringify-entities": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-          "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-          "requires": {
-            "character-entities-html4": "^1.0.0",
-            "character-entities-legacy": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-hexadecimal": "^1.0.0"
-          }
-        },
-        "unified": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-4.2.1.tgz",
-          "integrity": "sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=",
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "has": "^1.0.1",
-            "once": "^1.3.3",
-            "trough": "^1.0.0",
-            "vfile": "^1.0.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "unist-util-remove-position": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-          "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-          "requires": {
-            "unist-util-visit": "^1.1.0"
-          }
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        },
-        "vfile": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
-          "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c="
-        },
-        "vfile-location": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-          "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
-        }
-      }
-    },
-    "unist-util-find-all-after": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.1.tgz",
-      "integrity": "sha512-0GICgc++sRJesLwEYDjFVJPJttBpVQaTNgc6Jw0Jhzvfs+jtKePEMu+uD+PqkRUrAvGQqwhpDwLGWo1PK8PDEw==",
-      "requires": {
-        "unist-util-is": "^4.0.0"
-      }
-    },
-    "unist-util-find-all-before": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-before/-/unist-util-find-all-before-2.0.5.tgz",
-      "integrity": "sha512-lYakZyw3trON5qbsOsmtRARZTyKcQN8pkoMKLy558Nt8WhlqGAnRSD9qLrISkMKbS+0nhj8LiebgoheUtQXOZw==",
-      "requires": {
-        "unist-util-is": "^4.0.0"
-      }
-    },
-    "unist-util-find-all-between": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-between/-/unist-util-find-all-between-2.1.0.tgz",
-      "integrity": "sha512-OCCUtDD8UHKeODw3TPXyFDxPCbpgBzbGTTaDpR68nvxkwiVcawBqMVrokfBMvUi7ij2F5q7S4s4Jq5dvkcBt+w==",
-      "requires": {
-        "unist-util-find": "^1.0.1",
-        "unist-util-is": "^4.0.2"
-      }
-    },
-    "unist-util-generated": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.5.tgz",
-      "integrity": "sha512-1TC+NxQa4N9pNdayCYA1EGUOCAO0Le3fVp7Jzns6lnua/mYgwHo0tz5WUAfrdpNch1RZLHc61VZ1SDgrtNXLSw=="
-    },
     "unist-util-is": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
       "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
-    },
-    "unist-util-position": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
-      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
     },
     "unist-util-remove-position": {
       "version": "2.0.1",
@@ -11775,18 +11176,6 @@
       "integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
       "requires": {
         "unist-util-visit": "^2.0.0"
-      }
-    },
-    "unist-util-select": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-3.0.1.tgz",
-      "integrity": "sha512-VQpTuqZVJlRbosQdnLdTPIIqwZeU70YZ5aMBOqtFNGeeCdYn6ORZt/9RiaVlbl06ocuf58SVMoFa7a13CSGPMA==",
-      "requires": {
-        "css-selector-parser": "^1.0.0",
-        "not": "^0.1.0",
-        "nth-check": "^1.0.0",
-        "unist-util-is": "^4.0.0",
-        "zwitch": "^1.0.0"
       }
     },
     "unist-util-stringify-position": {
@@ -12360,22 +11749,6 @@
         }
       }
     },
-    "wrapped": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wrapped/-/wrapped-1.0.1.tgz",
-      "integrity": "sha1-x4PZ2Aeyc+mwHoUWgKk4yHyQckI=",
-      "requires": {
-        "co": "3.1.0",
-        "sliced": "^1.0.1"
-      },
-      "dependencies": {
-        "co": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-        }
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -12572,11 +11945,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-    },
-    "zwitch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"regenerator-runtime": "^0.13.7",
 		"remark": "^12.0.1",
 		"remark-lint": "^7.0.1",
-		"remark-preset-lint-origami-component": "^1.1.3",
 		"root-check": "^1.0.0",
 		"sass": "^1.26.10",
 		"sass-true": "^6.0.0",


### PR DESCRIPTION
No longer provide default sass, js, or readme lint configuration
when not provided by the component.

We think this is more transparent and ensures components provide
local configuration, which can be used by other tools such as
text editors to present errors to engineers before running Origami
Build Tools.

However:
- The component spec does not require these files, therefore Origami
Build Tools technically would be unable to verify Origami compatible
components. I think this is technically bad but not actually bad.
- The error isn't super helpful. Since the verify tasks run in parallel
I don't think we can ask "should we add the missing config for you"?
Maybe a link somewhere or a dump of what config we expect could be
more helpful?

Note: This is a major release. Not all of our components have these
lint files. E.g. I notice `o-message` is missing the readme lint
config `.remarkrc.js`.

Closes: https://github.com/Financial-Times/origami-build-tools/issues/876