### PR TITLE
Update stylelint/eslint ignore paths.

### DIFF
--- a/lib/tasks/verify-javascript.js
+++ b/lib/tasks/verify-javascript.js
@@ -3,7 +3,6 @@
 const process = require('process');
 const path = require('path');
 const ESLint = require('eslint').ESLint;
-const gitignore = require('parse-gitignore');
 const denodeify = require('util').promisify;
 const deglob = denodeify(require('deglob'));
 const fs = require('fs-extra');
@@ -14,10 +13,6 @@ async function lint (config) {
 	const hasJS = await projectHasJavaScriptFiles(config);
 
 	if (hasJS) {
-		const gitignorePath = path.join(config.cwd, '/.gitignore');
-		const hasGitignore = await fs.exists(gitignorePath);
-		const ignorePatterns = hasGitignore ? gitignore(await fs.readFile(gitignorePath)) : ['bower_components/', 'node_modules/'];
-
 		// Get eslint config from the component directory.
 		const eslintFile = '.eslintrc.js';
 		const eslintPath = path.join(config.cwd, eslintFile);
@@ -27,9 +22,8 @@ async function lint (config) {
 		}
 
 		const eslint = new ESLint({
-			baseConfig: {
-				ignorePatterns,
-			},
+			baseConfig: {},
+			ignorePath: '.gitignore',
 			overrideConfigFile: eslintPath,
 			useEslintrc: false
 		});

--- a/lib/tasks/verify-sass.js
+++ b/lib/tasks/verify-sass.js
@@ -2,7 +2,6 @@
 
 const process = require('process');
 const path = require('path');
-const gitignore = require('parse-gitignore');
 const lint = require('stylelint');
 const denodeify = require('util').promisify;
 const deglob = denodeify(require('deglob'));
@@ -13,18 +12,6 @@ async function sassLint(config) {
 	const hasScss = await projectHasScssFiles(config);
 
 	if (hasScss) {
-		const gitignorePath = path.join(config.cwd, '/.gitignore');
-		const hasGitignore = await fs.exists(gitignorePath);
-		const gitIgnorePatterns = hasGitignore ? gitignore(await fs.readFile(gitignorePath)).filter(a => !a.startsWith('!')).map(a => `!${a}`) : [];
-		const ignorePatterns = [
-			'!**/bower_components/**',
-			'!**/node_modules/**',
-			'!./bower_components/**',
-			'!./node_modules/**',
-			'!bower_components/**',
-			'!node_modules/**'
-		].concat(gitIgnorePatterns);
-
 		// Get stylelint config from the component directory.
 		const stylelintFile = '.stylelintrc.js';
 		const stylelintPath = path.join(config.cwd, stylelintFile);
@@ -34,7 +21,8 @@ async function sassLint(config) {
 		}
 
 		const result = await lint.lint({
-			files: [path.join(config.cwd, '**/*.scss'), ...ignorePatterns],
+			files: [path.join(config.cwd, '**/*.scss')],
+			ignorePath: '.gitignore',
 			configFile: stylelintPath,
 			configBasedir: path.join(__dirname, '../../'),
 			formatter: "compact"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7482,11 +7482,6 @@
         "is-hexadecimal": "^1.0.0"
       }
     },
-    "parse-gitignore": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-1.0.1.tgz",
-      "integrity": "sha512-UGyowyjtx26n65kdAMWhm6/3uy5uSrpcuH7tt+QEVudiBoVS+eqHxD5kbi9oWVRwj7sCzXqwuM+rUGw7earl6A=="
-    },
     "parse-help": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-help/-/parse-help-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"mustache": "^4.0.1",
 		"node-sass": "^4.14.0",
 		"pa11y": "^5.3.0",
-		"parse-gitignore": "^1.0.1",
 		"portfinder": "^1.0.26",
 		"postcss": "^7.0.27",
 		"proclaim": "^3.6.0",


### PR DESCRIPTION
Use the component's `.gitignore` instead of parsing `.gitignore`
paths within origami build tools. This means `.eslintignore` is
not used and there is no fallback if `.gitignore` is not specified.

The latter is not a problem, the former maybe? The only component
which currently uses `.eslintignore` is `o-tracking`, and those
are old/`.gitignore` duplicates:
https://github.com/Financial-Times/o-tracking/blob/04862efac02f7fc952c505b9335a92b5166c0b34/.eslintignore#L2