### PR TITLE
Make pa11y run against all supported brands and build the pa11y demo before it runs

### DIFF
--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -4,10 +4,12 @@ const denodeify = require('util').promisify;
 const fs = require('fs');
 const path = require('path');
 const isCI = require('is-ci');
+const files = require('../helpers/files');
+const buildDemo = require('./demo-build');
 
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 
-const pa11yTest = async function (config) {
+const pa11yTest = async function (config, brand) {
 	const pa11y = require('pa11y');
 	const src = path.join(config.cwd, '/demos/local/pa11y.html');
 
@@ -53,7 +55,7 @@ const pa11yTest = async function (config) {
 				console.log(`::error file=demos/src/pa11y.mustache,line=1,col=1::${message}`);
 			});
 		}
-		throw new Error('Accessibility errors were found in demos/src/pa11y.mustache\n' + errors.join('\n') + '\nFailed Pa11y tests');
+		throw new Error(`Accessibility errors were found in demos/src/pa11y.mustache when built for ${brand}\n` + errors.join('\n') + '\nFailed Pa11y tests');
 	}
 
 	return results;
@@ -65,9 +67,27 @@ module.exports = function (cfg) {
 
 	return {
 		title: 'Executing Pa11y',
-		task: () => pa11yTest(config),
+		task: async () => {
+			const brand = config.brand;
+			if (brand) {
+				await buildDemo({
+					brand,
+					demoFilter: 'pa11y'
+				});
+				return pa11yTest(config, brand);
+			} else {
+				const brands = await files.getModuleBrands();
+				for (const brand of brands) {
+					await buildDemo({
+						brand,
+						demoFilter: 'pa11y'
+					});
+					return pa11yTest(config, brand);
+				}
+			}
+		},
 		skip: function () {
-			return fileExists(path.join(config.cwd, '/demos/local/pa11y.html'))
+			return fileExists(path.join(config.cwd, '/demos/src/pa11y.mustache'))
 				.then(exists => {
 					if (!exists) {
 						return `No Pa11y demo found. To run Pa11y against this project, create a file at ${path.join(config.cwd, '/demos/local/pa11y.html')}`;

--- a/test/unit/tasks/pa11y.test.js
+++ b/test/unit/tasks/pa11y.test.js
@@ -64,12 +64,12 @@ describe('Test task', function() {
 
 		describe('skip', () => {
 			it('should return a truthy value if the file does not exist', function() {
-				fs.removeSync(path.join(process.cwd(), '/demos/local/pa11y.html'));
+				fs.removeSync(path.join(process.cwd(), '/demos/src/pa11y.mustache'));
 				return pa11y().skip().then(result => proclaim.isTrue(Boolean(result)));
 			});
 
 			it('should return a helpful message if the file does not exist', function() {
-				fs.removeSync(path.join(process.cwd(), '/demos/local/pa11y.html'));
+				fs.removeSync(path.join(process.cwd(), '/demos/src/pa11y.mustache'));
 				return pa11y().skip().then(result => proclaim.equal(result, `No Pa11y demo found. To run Pa11y against this project, create a file at ${path.join(process.cwd(), '/demos/local/pa11y.html')}`));
 			});
 


### PR DESCRIPTION
This allows component which are built for a single brand to have a pa11y demo which works.

Solves - https://github.com/Financial-Times/origami-ci-tools/issues/23 and https://github.com/Financial-Times/o-meter/issues/2

This changes the pa11y task to not require `obt demo` to have been run first by the user.