### PR TITLE
pass through the ignore bower flag when building the pa11y demo

### DIFF
--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -80,7 +80,8 @@ module.exports = function (cfg) {
 				for (const brand of brands) {
 					await buildDemo({
 						brand,
-						demoFilter: 'pa11y'
+						demoFilter: 'pa11y',
+						ignoreBower: config.ignoreBower,
 					});
 					return pa11yTest(config, brand);
 				}


### PR DESCRIPTION
Currently the ignorebower flag is not passed through which is making the pa11y test fail for the npm version of our components