### PR TITLE
Make git pushes in create-new-version workflow trigger other workflows

### DIFF
--- a/.github/workflows/automatic-tag-and-release.yml
+++ b/.github/workflows/automatic-tag-and-release.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }} # Checkout the merged commit
           fetch-depth: 0
+          token: ${{ secrets.ORIGAMI_VERSION_TOKEN }}
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Get all tags from the origin
         if: github.event.pull_request.merged # Only run on merged pull-requests
       - uses: Financial-Times/origami-version@v1.2.0


### PR DESCRIPTION
Same as https://github.com/Financial-Times/origami-build-tools/pull/952 but targeted at the v11 branch

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token

> Currently we are using the read-only github token. When using this token and pushing commits/tags to github, github will not trigger any workflows for the pushed commit/tag.
> 
> We need the pushed tag to trigger out npm-publishing workflows, which means we need to use a custom github token instead of the default token provided by github actions.