### PR TITLE
Add missing methods to the mock console used in pa11y tests

### DIFF
--- a/test/unit/tasks/pa11y.test.js
+++ b/test/unit/tasks/pa11y.test.js
@@ -32,7 +32,9 @@ describe('Test task', function() {
 				warnOnUnregistered: false
 			});
 			console = {
-				log: sinon.stub()
+				log: sinon.stub(),
+				warn: sinon.stub(),
+				error: sinon.stub()
 			};
 			mockery.registerMock('is-ci', true);
 			process.env.CI = true;


### PR DESCRIPTION
There was a changed in pa11y where it started to use console.warn, which is a method that doesn't exist in our current mock console and as such was throwing an error when testing.

We need to fix this to unblock other obt pull-requests such as this one https://github.com/Financial-Times/origami-build-tools/pull/955