### PR TITLE
inline the demo css and js into the html

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Origami Build Tools provides boilerplate for creating up a new Origami component
 		--browserstack             Run tests using Browserstack instead of Chrome Stable
 		--demo-filter=<demo-name>  Build a specific demo. E.G. --demo-filter=pa11y to build only the pa11y.html demo.
 		--brand=<brand-name>       Build SCSS for a given brand. E.G. --brand=internal to build the component for the internal brand.
+		--single-file-demo         Build the demo html as a single file which has the demo css and js inlined.
 		--debug                    Keep the test runner open to enable debugging in any browser.
 
 ## Commands

--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -44,8 +44,7 @@ function packageLockJsonExists(cwd) {
 	return fileExists(path.join(cwd || process.cwd(), '/package-lock.json'));
 }
 
-function getOrigamiJson(cwd) {
-	cwd = cwd || process.cwd();
+function getOrigamiJson(cwd = process.cwd()) {
 	return requireIfExists(path.join(cwd, '/origami.json'));
 }
 
@@ -94,9 +93,9 @@ function getModuleBrands(cwd) {
 /**
  * Get individual demo configuration for the component.
  * @param {string} cwd - The component's directory (the current working directory).
- * @return {array<object>} - An array of objects representing a component demo.
+ * @return {Promise<Array<object>>} - An array of objects representing a component demo.
  */
-async function getComponentDemos(cwd) {
+async function getComponentDemos(cwd = process.cwd()) {
 	const origamiJson = await getOrigamiJson(cwd);
 	if (origamiJson && origamiJson.demos && Array.isArray(origamiJson.demos)) {
 		return origamiJson.demos;
@@ -107,9 +106,9 @@ async function getComponentDemos(cwd) {
 /**
  * Get shared demo configuration.
  * @param {string} cwd - The component's directory (the current working directory).
- * @return {object} - An object of configuration.
+ * @return {Promise<object>} - An object of configuration.
  */
-async function getComponentDefaultDemoConfig(cwd) {
+async function getComponentDefaultDemoConfig(cwd = process.cwd()) {
 	const origamiJson = await getOrigamiJson(cwd);
 	if (origamiJson && origamiJson.demosDefaults && typeof origamiJson.demosDefaults === 'object') {
 		return origamiJson.demosDefaults;

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -38,6 +38,7 @@ const help = `
 			-v, --version              Print out version of origami-build-tools
 			--browserstack             Run tests using Browserstack instead of Chrome Stable. Requires BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY to be set.
 			--demo-filter=<demo-name>  Build a specific demo. E.G. --demo-filter=pa11y to build only the pa11y.html demo.
+			--single-file-demo         Build the demo html as a single file which has the demo css and js inlined.
 			--debug                    Keep the test runner open to enable debugging in any browser.
 
 		Full documentation

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -8,6 +8,7 @@ const buildJs = require('../tasks/build-js');
 const buildSass = require('../tasks/build-sass');
 const constructPolyfillUrl = require('../helpers/construct-polyfill-url');
 const mustache = require('mustache');
+const { readIfExists } = require('../helpers/files');
 const denodeify = require('util').promisify;
 
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
@@ -35,7 +36,8 @@ function buildDemoSass(buildConfig) {
 				buildCss: path.basename(buildConfig.demo.sass).replace('.scss', '.css'),
 				buildFolder: dest,
 				cwd: buildConfig.cwd,
-				brand: buildConfig.brand
+				brand: buildConfig.brand,
+				outputStyle: 'compressed'
 			};
 
 			return buildSass(sassConfig);
@@ -126,7 +128,7 @@ function buildDemoHtml(buildConfig) {
 				})
 			]);
 		})
-		.then(([
+		.then(async ([
 			moduleName,
 			oDemoTpl
 		]) => {
@@ -137,18 +139,26 @@ function buildDemoHtml(buildConfig) {
 			data.oDemoTitle = moduleName + ': ' + buildConfig.demo.name + ' demo';
 			data.oDemoDocumentClasses = buildConfig.demo.documentClasses || buildConfig.demo.bodyClasses;
 
-			data.oDemoComponentStylePath = sassPath ?
-				path.basename(sassPath).replace('.scss', '.css') :
-				'';
+			if (buildConfig.singleFileDemo) {
 
-			data.oDemoComponentScriptPath = jsPath ? path.basename(jsPath) : '';
+				const destFolder = path.join(buildConfig.cwd, '/demos/local/');
+				const jsdest = path.join(destFolder, path.basename(buildConfig.demo.js));
+				const cssdest = path.join(destFolder, path.basename(sassPath).replace('.scss', '.css'));
+
+				data.oDemoComponentStyle = await readIfExists(cssdest) || '';
+				data.oDemoComponentScript = await readIfExists(jsdest) || '';
+			} else {
+				data.oDemoComponentStylePath = sassPath ? path.basename(sassPath).replace('.scss', '.css') : '';
+
+				data.oDemoComponentScriptPath = jsPath ? path.basename(jsPath) : '';
+			}
 
 			data.oDemoDependenciesStylePath = dependencies ?
-				`https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${dependencies.toString()}${brand ? `&brand=${brand}` : ''}` :
+				`https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=origami&modules=${dependencies.toString()}&brand=${brand || 'master'}` :
 				'';
 
 			data.oDemoDependenciesScriptPath = dependencies ?
-				'https://www.ft.com/__origami/service/build/v2/bundles/js?modules=' + dependencies.toString() :
+				'https://www.ft.com/__origami/service/build/v3/bundles/js?system_code=origami&modules=' + dependencies.toString() :
 				'';
 
 			configuredPartials.oDemoTpl = String(oDemoTpl);
@@ -257,7 +267,8 @@ module.exports = async function (cfg) {
 		const buildConfig = {
 			demo: demoBuild || {},
 			brand: config.brand,
-			cwd: cwd
+			cwd: cwd,
+			singleFileDemo: config.singleFileDemo
 		};
 		// Add demo html config.
 		htmlBuildsConfig.push(buildConfig);
@@ -276,10 +287,19 @@ module.exports = async function (cfg) {
 		}
 	}
 
-	// Return build promises for all demo assets.
-	return Promise.all([
-		...htmlBuildsConfig.map(c => buildDemoHtml(c)),
-		...sassBuildsConfig.map(c => buildDemoSass(c)),
-		...jsBuildsConfig.map(c => buildDemoJs(c))
-	]);
+	if (config.singleFileDemo) {
+		// Need to build sass and js first because the html reads the built css and js files
+		await Promise.all([
+			...sassBuildsConfig.map(c => buildDemoSass(c)),
+			...jsBuildsConfig.map(c => buildDemoJs(c))
+		]);
+		return Promise.all(htmlBuildsConfig.map(c => buildDemoHtml(c)));
+	} else {
+		// Return build promises for all demo assets.
+		return Promise.all([
+			...htmlBuildsConfig.map(c => buildDemoHtml(c)),
+			...sassBuildsConfig.map(c => buildDemoSass(c)),
+			...jsBuildsConfig.map(c => buildDemoJs(c))
+		]);
+	}
 };

--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
 		"test:unit": "make test-unit",
 		"test:integration": "make test-integration"
 	},
-	"snyk": true
+	"snyk": true,
+	"volta": {
+		"node": "14.15.4"
+	}
 }

--- a/templates/page.mustache
+++ b/templates/page.mustache
@@ -15,10 +15,6 @@
 		<script src="{{{oDemoPolyfillUrl}}}"></script>
 	{{/oDemoPolyfillUrl}}
 
-	{{#oDemoComponentScriptPath}}
-		<script src="{{{ oDemoComponentScriptPath }}}" defer></script>
-	{{/oDemoComponentScriptPath}}
-
 	{{#oDemoDependenciesScriptPath}}
 		<script src="{{{ oDemoDependenciesScriptPath }}}" defer></script>
 	{{/oDemoDependenciesScriptPath}}
@@ -30,9 +26,19 @@
 	{{#oDemoComponentStylePath}}
 		<link rel="stylesheet" href="{{{.}}}" />
 	{{/oDemoComponentStylePath}}
+
+	{{#oDemoComponentStyle}}
+		<style>{{{.}}}</style>
+	{{/oDemoComponentStyle}}
 </head>
 <body>
 	{{> oDemoTpl}}
 	<script src="https://registry.origami.ft.com/embedapi?autoload=resize"></script>
+	{{#oDemoComponentScriptPath}}
+		<script src="{{{ oDemoComponentScriptPath }}}" defer></script>
+	{{/oDemoComponentScriptPath}}
+	{{#oDemoComponentScript}}
+		<script>{{{ oDemoComponentScript }}}</script>
+	{{/oDemoComponentScript}}
 </body>
 </html>

--- a/test/integration/demo/demo.test.js
+++ b/test/integration/demo/demo.test.js
@@ -186,11 +186,11 @@ describe('obt demo', function () {
 
 		it('should include a request to the Origami Build Service in demo markup for demo dependencies', function () {
 			// demo dependency css
-			proclaim.include(builtDemoHtml1, '<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^4.0.0" />');
-			proclaim.include(builtDemoHtml2, '<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^4.0.0" />');
+			proclaim.include(builtDemoHtml1, '<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=origami&modules=o-fonts@^4.0.0&brand=master" />');
+			proclaim.include(builtDemoHtml2, '<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=origami&modules=o-fonts@^4.0.0&brand=master" />');
 			// demo dependency js
-			proclaim.include(builtDemoHtml1, 'https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-fonts@^4.0.0');
-			proclaim.include(builtDemoHtml2, 'https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-fonts@^4.0.0');
+			proclaim.include(builtDemoHtml1, '<script src="https://www.ft.com/__origami/service/build/v3/bundles/js?system_code=origami&modules=o-fonts@^4.0.0" defer></script>');
+			proclaim.include(builtDemoHtml2, '<script src="https://www.ft.com/__origami/service/build/v3/bundles/js?system_code=origami&modules=o-fonts@^4.0.0" defer></script>');
 		});
 
 		it('should build demo css', function () {
@@ -250,6 +250,63 @@ describe('obt demo', function () {
 				expectedJsInDemo2,
 				'Expected demo 2 javascript to include demo specific javascript.'
 			);
+		});
+	});
+
+	describe('component demo built as single file', function () {
+		const testDirectory = uniqueTempDir({ create: true });
+		const fixturesDirectory = path.resolve(__dirname, 'fixtures/multiple-demos');
+		const expectedBuiltDemoPath2 = path.resolve(testDirectory, 'demos/local/demo-2.html');
+		let builtDemoHtml2 = '';
+
+		before(async function () {
+			// copy fixture (example component with multiple demos)
+			// to a temporary test directory
+			fs.copySync(fixturesDirectory, testDirectory);
+			process.chdir(testDirectory);
+			const obt = await obtBinPath();
+			// Run obt demo
+			await execa(obt, ['demo', '--single-file-demo', '--demo-filter=demo-2']);
+			// Get the built demo html content we expect
+			// If the file is not found move on, later test
+			// assertions will cover that
+			try {
+				builtDemoHtml2 = fs.readFileSync(expectedBuiltDemoPath2, 'utf8');
+			} catch(e) {
+				// assume no files found
+			}
+		});
+
+		after(function () {
+			// remove temporary test directory
+			process.chdir(process.cwd());
+			return rimraf(testDirectory);
+		});
+
+		it('should have created a html file for each demo', function () {
+			proclaim.ok(
+				fileExists(expectedBuiltDemoPath2),
+				'Could not find the built demo html file for demo-2.'
+			);
+		});
+
+		it('should have rendered demo html in the body of the demo template', function () {
+			proclaim.include(builtDemoHtml2, 'demo 2');
+		});
+
+		it('should have included demo css in the demo html', function () {
+			proclaim.include(builtDemoHtml2, '<style>.demo-two{content:"demo 2 here"}');
+		});
+
+		it('should have included demo javascript in the demo html', function () {
+			proclaim.include(builtDemoHtml2, '(function () {\n  // demos/src/demo-2.js\n  var demoTwo = "demo 2 here";\n  console.log(demoTwo);\n})();');
+		});
+
+		it('should include a request to the Origami Build Service in demo markup for demo dependencies', function () {
+			// demo dependency css
+			proclaim.include(builtDemoHtml2, '<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=origami&modules=o-fonts@^4.0.0&brand=master" />');
+			// demo dependency js
+			proclaim.include(builtDemoHtml2, '<script src="https://www.ft.com/__origami/service/build/v3/bundles/js?system_code=origami&modules=o-fonts@^4.0.0" defer></script>');
 		});
 	});
 });

--- a/test/unit/fixtures/o-test/main.scss
+++ b/test/unit/fixtures/o-test/main.scss
@@ -3,7 +3,7 @@
 @if (not $o-test-is-silent) {
 	div {
 		@if global-variable-exists(o-brand) {
-			content: Brand is set to #{$o-brand};
+			content: "Brand is set to #{$o-brand}";
 		}
 		color: blue;
 	}

--- a/test/unit/tasks/build-sass.test.js
+++ b/test/unit/tasks/build-sass.test.js
@@ -87,8 +87,8 @@ describe('Build Sass', function () {
 		})
 			.then(function (result) {
 				const builtCss = fs.readFileSync('build/bundle.css', 'utf8');
-				proclaim.include(builtCss, 'div {\n  content: Brand is set to internal;\n  color: blue;\n}');
-				proclaim.include(result, 'div {\n  content: Brand is set to internal;\n  color: blue;\n}');
+				proclaim.include(builtCss, 'div {\n  content: "Brand is set to internal";\n  color: blue;\n}');
+				proclaim.include(result, 'div {\n  content: "Brand is set to internal";\n  color: blue;\n}');
 			});
 	});
 


### PR DESCRIPTION
This makes the demos each become a single file, which makes it possible for the origami build service to serve the single file via the /v3/demos endpoint (which is still being built).