### PR TITLE
Make pa11y work on components which have no explicilty defined their brand support

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -84,17 +84,18 @@ function getComponentName(cwd) {
 function getModuleBrands(cwd) {
 	return getOrigamiJson(cwd)
 		.then(origamiJson => {
-			if (origamiJson && origamiJson.brands && Array.isArray(origamiJson.brands)) {
+			const hasBrandsDefined = origamiJson && origamiJson.brands && Array.isArray(origamiJson.brands) && origamiJson.brands.length > 0;
+			if (hasBrandsDefined) {
 				return origamiJson.brands;
 			}
-			return [];
+			return ['master', 'internal', 'whitelabel'];
 		});
 }
 
 /**
  * Get individual demo configuration for the component.
  * @param {string} cwd - The component's directory (the current working directory).
- * @return {array<object>} - An array of objects representing a component demo.
+ * @return {Promise<Array<object>>} - An array of objects representing a component demo.
  */
 async function getComponentDemos(cwd) {
 	const origamiJson = await getOrigamiJson(cwd);

--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -73,13 +73,15 @@ module.exports = function (cfg) {
 				return pa11yTest(config, brand);
 			} else {
 				const brands = await files.getModuleBrands();
+				const results = [];
 				for (const brand of brands) {
 					await buildDemo({
 						brand,
 						demoFilter: 'pa11y',
 					});
-					return pa11yTest(config, brand);
+					results.push(pa11yTest(config, brand));
 				}
+				return Promise.all(results);
 			}
 		},
 		skip: async function () {

--- a/test/unit/config/karma-config.test.js
+++ b/test/unit/config/karma-config.test.js
@@ -35,7 +35,7 @@ describe('base karma config', () => {
 			const actualScssConfig = actualConfig.scssPreprocessor.options.data;
 			proclaim.equal(
 				actualScssConfig,
-				`$system-code: "origami-build-tools";$${mockName}-is-silent: false; ${mockScss}`
+				`$system-code: "origami-build-tools";$o-brand: master;$${mockName}-is-silent: false; ${mockScss}`
 			);
 		});
 	});

--- a/test/unit/helpers/files.test.js
+++ b/test/unit/helpers/files.test.js
@@ -277,4 +277,30 @@ describe('Files helper', function () {
 			proclaim.lengthEquals(Object.keys(demosDefaults), 0, 'Expected an empty object given missing default demo configuration.');
 		});
 	});
+
+	describe('getModuleBrands', function() {
+		context('if no brands are defined', function() {
+			it('should return an array containing only `master`, `internal`, `whitelabel`', async function(){
+				const brands = await files.getModuleBrands();
+				proclaim.deepStrictEqual(brands, ['master', 'internal', 'whitelabel']);
+			});
+		});
+
+		context('if brands is defined as an array with no items', function(){
+			it('should return an array containing only `master`, `internal`, `whitelabel`', async function(){
+				const brands = await files.getModuleBrands();
+				proclaim.deepStrictEqual(brands, ['master', 'internal', 'whitelabel']);
+			});
+		});
+
+		context('if brands is defined as an array with items', function(){
+			it('should return an arary with the same items as those defined', async function() {
+				const origamiManifest = JSON.parse(fs.readFileSync('origami.json', 'utf8'));
+				origamiManifest.brands = ['master'];
+				fs.writeFileSync('origami.json', JSON.stringify(origamiManifest), 'utf8');
+				const brands = await files.getModuleBrands();
+				proclaim.deepStrictEqual(brands, ['master']);
+			});
+		});
+	});
 });


### PR DESCRIPTION
we don't actually specify what the default brand is [if no brand is defined](https://origami.ft.com/spec/v1/manifest/#brands)...

We know it should be `master` though, so that is what this pull-request changes `getModuleBrands` to return if no brands are defined.

This also fixes a bug in the pa11y task where it would only run pa11y on the first brand defined for the component and not for all the brands defined.