### PR TITLE
Throw a helpful error when running outside a v2 component directory.

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -193,6 +193,7 @@ function getSassIncludePaths (cwd, config = {sassIncludePaths: []}) {
 module.exports.readIfExists = readIfExists;
 module.exports.getBuildFolderPath = getBuildFolderPath;
 module.exports.getMainSassPath = getMainSassPath;
+module.exports.getOrigamiJson = getOrigamiJson;
 module.exports.getMainJsPath = getMainJsPath;
 module.exports.getPackageJson = getPackageJson;
 module.exports.packageJsonExists = packageJsonExists;

--- a/lib/helpers/verify-component-specification-version.js
+++ b/lib/helpers/verify-component-specification-version.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { getOrigamiJson } = require('./files');
+
+/**
+ * @throws {Error} - Throws an error if not in a component directory which follows v2 or higher of the Origami Component Specification.
+ * @returns {undefined}
+ */
+module.exports = async () => {
+	const origamiJson = await getOrigamiJson();
+	if (!origamiJson || typeof origamiJson.origamiVersion !== 'number') {
+		throw new Error(
+			'Is this an Origami component? \n\n' +
+			'Origami Build Tools may only be used to develop Origami ' +
+			'components. It looks like this isn\'t an Origami component, ' +
+			'or the component is missing a valid "origami.json". See the ' +
+			'component specification for more details: ' +
+			'https://origami.ft.com/spec/'
+		);
+	}
+	if (origamiJson.origamiVersion === 1) {
+		throw new Error(
+			'This version of Origami Build Tools does not support components ' +
+			'which follow v1 of the Origami component specification. ' +
+			'To work on this component install a previous version of the ' +
+			'Origami Build Tools (v10). Alternatively, upgrade this ' +
+			'component to follow v2 or above of the Origami specification. ' +
+			'See the component specification for more details: ' +
+			'https://origami.ft.com/spec/'
+		);
+	}
+};

--- a/lib/origami-build-tools-cli.js
+++ b/lib/origami-build-tools-cli.js
@@ -14,6 +14,7 @@ const path = require('path');
 const portfinder = require('portfinder');
 const boxen = require('boxen');
 const log = require('./helpers/log');
+const verifyComponentSpecificationVersion = require('./helpers/verify-component-specification-version');
 
 const rootCheck = require('root-check');
 rootCheck(`You are not allowed to run this app with root permissions.
@@ -152,48 +153,58 @@ switch (argument) {
 		break;
 }
 
-if (task && (argument === 'develop' || argument === 'dev')) {
-	// start a server to show demos
-	const port = cli.flags.port || 8999;
-	startServer(port);
-	// build demos whenever changes are detected
-	let childProcess;
-	const devArguments = cli.flags.brand ?
-		['demo', '--brand', cli.flags.brand] :
-		['demo'];
-	chokidar.watch(cli.flags.cwd || process.cwd(), {
-		ignored: [
-			'node_modules',
-			'build',
-			'.git',
-			'demos/local'
-		],
-		persistent: true,
-		followSymlinks: true,
-		ignoreInitial: true,
-		cwd: cli.flags.cwd || process.cwd()
-	})
-		.on('all', function () {
-			// Clear console
-			console.log('\x1Bc');
-			if (childProcess) {
-				childProcess.kill();
-			}
-
-			childProcess = runWatchedTask(devArguments);
+(async() => {
+	if (task) {
+		try {
+			await verifyComponentSpecificationVersion();
+		} catch (error) {
+			log.secondaryError(error.message);
+			process.exit(2);
+		}
+	}
+	if (task && (argument === 'develop' || argument === 'dev')) {
+		// start a server to show demos
+		const port = cli.flags.port || 8999;
+		startServer(port);
+		// build demos whenever changes are detected
+		let childProcess;
+		const devArguments = cli.flags.brand ?
+			['demo', '--brand', cli.flags.brand] :
+			['demo'];
+		chokidar.watch(cli.flags.cwd || process.cwd(), {
+			ignored: [
+				'node_modules',
+				'build',
+				'.git',
+				'demos/local'
+			],
+			persistent: true,
+			followSymlinks: true,
+			ignoreInitial: true,
+			cwd: cli.flags.cwd || process.cwd()
 		})
-		.on('ready', function () {
-			childProcess = runWatchedTask(devArguments);
-		});
-} else if (task) {
-	task(cli)
-		.catch(() => {
-			if (server) {
-				server.stop();
-			}
-			process.exitCode = 2;
-		});
-}
+			.on('all', function () {
+				// Clear console
+				console.log('\x1Bc');
+				if (childProcess) {
+					childProcess.kill();
+				}
+
+				childProcess = runWatchedTask(devArguments);
+			})
+			.on('ready', function () {
+				childProcess = runWatchedTask(devArguments);
+			});
+	} else if (task) {
+		task(cli)
+			.catch(() => {
+				if (server) {
+					server.stop();
+				}
+				process.exitCode = 2;
+			});
+	}
+})();
 
 function runWatchedTask(taskWithFlags) {
 	log.secondary('Press ctrl+c to exit.');

--- a/test/integration/install/fixtures/no-npm-dependencies/origami.json
+++ b/test/integration/install/fixtures/no-npm-dependencies/origami.json
@@ -1,0 +1,20 @@
+{
+    "description": "fixture, no-dependencies",
+    "keywords": [],
+    "origamiType": "module",
+    "origamiCategory": "components",
+    "origamiVersion": 2,
+    "brands": [],
+    "support": "https://github.com/Financial-Times/o-example/issues",
+    "supportContact": {
+        "email": "origami.support@ft.com",
+        "slack": "financialtimes/#origami-support"
+    },
+    "supportStatus": "experimental",
+    "browserFeatures": {},
+    "demosDefaults": {
+        "documentClasses": "",
+        "dependencies": []
+    },
+    "demos": []
+}

--- a/test/integration/install/fixtures/non-existent-npm-dependency/origami.json
+++ b/test/integration/install/fixtures/non-existent-npm-dependency/origami.json
@@ -1,0 +1,20 @@
+{
+    "description": "fixture, non-existent-npm-dependency",
+    "keywords": [],
+    "origamiType": "module",
+    "origamiCategory": "components",
+    "origamiVersion": 2,
+    "brands": [],
+    "support": "https://github.com/Financial-Times/o-example/issues",
+    "supportContact": {
+        "email": "origami.support@ft.com",
+        "slack": "financialtimes/#origami-support"
+    },
+    "supportStatus": "experimental",
+    "browserFeatures": {},
+    "demosDefaults": {
+        "documentClasses": "",
+        "dependencies": []
+    },
+    "demos": []
+}

--- a/test/integration/install/fixtures/with-npm-dependencies/origami.json
+++ b/test/integration/install/fixtures/with-npm-dependencies/origami.json
@@ -1,0 +1,20 @@
+{
+    "description": "fixture, with-npm-dependencies",
+    "keywords": [],
+    "origamiType": "module",
+    "origamiCategory": "components",
+    "origamiVersion": 2,
+    "brands": [],
+    "support": "https://github.com/Financial-Times/o-example/issues",
+    "supportContact": {
+        "email": "origami.support@ft.com",
+        "slack": "financialtimes/#origami-support"
+    },
+    "supportStatus": "experimental",
+    "browserFeatures": {},
+    "demosDefaults": {
+        "documentClasses": "",
+        "dependencies": []
+    },
+    "demos": []
+}

--- a/test/integration/test/fixtures/with-npm-dependency-installed/origami.json
+++ b/test/integration/test/fixtures/with-npm-dependency-installed/origami.json
@@ -1,0 +1,20 @@
+{
+    "description": "fixture, with-npm-dependency-installed",
+    "keywords": [],
+    "origamiType": "module",
+    "origamiCategory": "components",
+    "origamiVersion": 2,
+    "brands": [],
+    "support": "https://github.com/Financial-Times/o-example/issues",
+    "supportContact": {
+        "email": "origami.support@ft.com",
+        "slack": "financialtimes/#origami-support"
+    },
+    "supportStatus": "experimental",
+    "browserFeatures": {},
+    "demosDefaults": {
+        "documentClasses": "",
+        "dependencies": []
+    },
+    "demos": []
+}

--- a/test/unit/helpers/verify-component-specification-version.test.js
+++ b/test/unit/helpers/verify-component-specification-version.test.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+'use strict';
+
+const proclaim = require('proclaim');
+const mockery = require('mockery');
+
+describe('verify-component-specification-version', function () {
+
+	let verifyComponentSpecificationVersion;
+	let origamiManifest;
+
+	beforeEach(function () {
+		mockery.enable({
+			useCleanCache: true,
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		});
+		mockery.registerMock('./files', {
+			getOrigamiJson: () => new Promise(resolve => resolve(origamiManifest))
+		});
+		verifyComponentSpecificationVersion = require('../../../lib/helpers/verify-component-specification-version');
+	});
+
+	it('returns undefined for a component which follows version "2" of the spec', async function () {
+		origamiManifest = {
+			origamiVersion: 2
+		};
+		const result = await verifyComponentSpecificationVersion();
+		proclaim.isUndefined(result);
+	});
+
+	it('returns undefined for a component which follows some future version of the spec', async function () {
+		origamiManifest = {
+			origamiVersion: 9999
+		};
+		const result = await verifyComponentSpecificationVersion();
+		proclaim.isUndefined(result);
+	});
+
+	it('throws an error for a component which follows version "2" of the spec but is misconfigured with a string instead of a number', async function () {
+		origamiManifest = {
+			origamiVersion: "2"
+		};
+		try {
+			await verifyComponentSpecificationVersion();
+		} catch (error) {
+			return proclaim.ok(true);
+		}
+		proclaim.ok(false, 'No error was thrown');
+	});
+
+	it('throws an error for a component which follows version "1" of the spec', async function () {
+		origamiManifest = {
+			origamiVersion: 1
+		};
+		try {
+			await verifyComponentSpecificationVersion();
+		} catch (error) {
+			return proclaim.ok(true);
+		}
+		proclaim.ok(false, 'No error was thrown');
+	});
+
+	it('throws an error for a project which does not have an origami manifest file', async function () {
+		origamiManifest = null;
+		try {
+			await verifyComponentSpecificationVersion();
+		} catch (error) {
+			return proclaim.ok(true);
+		}
+		proclaim.ok(false, 'No error was thrown');
+	});
+});


### PR DESCRIPTION
When running on a directory with no `origami.json`, or misconfigured
`origamiVersion` property:

> Is this an Origami component?
>
> Origami Build Tools may only be used to develop Origami
> components. It looks like this isn\'t an Origami component,
> or the component is missing a valid "origami.json". See the
> component specification for more details:
> https://origami.ft.com/spec/'

When running on a v1 component:

> This version of Origami Build Tools does not support components
> which follow v1 of the Origami component specification.
> To work on this component install a previous version of the
> Origami Build Tools (v10). Alternatively, upgrade this
> component to follow v2 or above of the Origami specification.
> See the component specification for more details:
> https://origami.ft.com/spec/

Closes: https://github.com/Financial-Times/origami-build-tools/issues/943

![Screenshot 2021-02-19 at 12 12 06](https://user-images.githubusercontent.com/10405691/108505620-96379380-72af-11eb-858b-ce94a1bda399.png)
![Screenshot 2021-02-19 at 12 11 34](https://user-images.githubusercontent.com/10405691/108505627-98015700-72af-11eb-8748-48d9ccf36552.png)
