### PR TITLE
Verify package.json manifest has description and keywords

### DIFF
--- a/lib/tasks/verify-origami-json.js
+++ b/lib/tasks/verify-origami-json.js
@@ -20,9 +20,6 @@ function origamiJson(config) {
 					.then(file => {
 						const origamiJson = JSON.parse(file);
 						const componentDemos = origamiJson.demos;
-						if (!origamiJson.description) {
-							result.push('A non-empty description property is required');
-						}
 						if (origamiJson.origamiType !== 'imageset' && origamiJson.origamiType !== 'module' && origamiJson.origamiType !== 'service') {
 							result.push('The origamiType property needs to be set to either "imageset", "module" or "service"');
 						}

--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const process = require('process');
+const fs = require('fs');
+const path = require('path');
+const denodeify = require('util').promisify;
+const isCI = require('is-ci');
+
+const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
+const readFile = denodeify(fs.readFile);
+
+function packageJson(config) {
+	const result = [];
+
+	const packageJsonPath = path.join(config.cwd, '/package.json');
+	return fileExists(packageJsonPath)
+		.then(exists => {
+			if (exists) {
+				return readFile(packageJsonPath, 'utf8')
+					.then(file => {
+						const packageJson = JSON.parse(file);
+						if (typeof packageJson.description === 'string') {
+							if (packageJson.description.trim().length === 0) {
+								result.push('A description property is required. It must be a string which describes the component.');
+							}
+						} else {
+							result.push('A description property is required. It must be a string which describes the component.');
+						}
+						if (Array.isArray(packageJson.keywords)) {
+							if (packageJson.keywords.some(keyword => typeof keyword !== 'string' || keyword.trim().length === 0)) {
+								result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
+							}
+						} else {
+							result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
+						}
+
+						if (result.length > 0) {
+							const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management';
+							if (isCI) {
+								const newLine = "%0A";
+								console.log(`::error file=package.json,line=1,col=1::${message.replace(/\n/g, newLine)}`);
+							}
+							const e = new Error(message);
+							e.stack = '';
+							throw e;
+						} else {
+							return result;
+						}
+					});
+			}
+		});
+}
+
+module.exports = cfg => {
+	const config = cfg || {};
+	config.cwd = config.cwd || process.cwd();
+
+	return {
+		title: 'Verifying your package.json',
+		task: () => packageJson(config),
+		skip: function () {
+			const packageJsonPath = path.join(config.cwd, '/package.json');
+
+			return fileExists(packageJsonPath)
+				.then(exists => {
+					if (!exists) {
+						return `No package.json file found. To make this an origami component, create a file at ${path.join(config.cwd, '/package.json')} following the format defined at: https://origami.ft.com/spec/v2/components/#package-management`;
+					}
+				});
+		}
+	};
+};

--- a/lib/tasks/verify.js
+++ b/lib/tasks/verify.js
@@ -3,6 +3,7 @@
 const Listr = require("listr");
 const ListrRenderer = require("../helpers/listr-renderer");
 const verifyOrigamiJsonFile = require("./verify-origami-json");
+const verifyPackageJsonFile = require("./verify-package-json");
 const verifyJavaScript = require("./verify-javascript");
 const verifySass = require("./verify-sass");
 const verifyReadme = require("./verify-readme");
@@ -15,6 +16,7 @@ module.exports = function(cfg) {
 	return new Listr(
 		[
 			verifyOrigamiJsonFile(config),
+			verifyPackageJsonFile(config),
 			verifyReadme(config),
 			verifyJavaScript(config),
 			verifySass(config),

--- a/test/integration/verify/fixtures/js-custom-eslint/origami.json
+++ b/test/integration/verify/fixtures/js-custom-eslint/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/js-es5/origami.json
+++ b/test/integration/verify/fixtures/js-es5/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/js-es5/package.json
+++ b/test/integration/verify/fixtures/js-es5/package.json
@@ -1,5 +1,7 @@
 {
 	"name": "test-component",
+	"description": "for a fixture",
+	"keywords": [],
 	"main": [
 		"main.js"
 	],

--- a/test/integration/verify/fixtures/js-es6/origami.json
+++ b/test/integration/verify/fixtures/js-es6/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/js-es6/package.json
+++ b/test/integration/verify/fixtures/js-es6/package.json
@@ -1,5 +1,7 @@
 {
 	"name": "test-component",
+	"description": "for a fixture",
+	"keywords": [],
 	"main": [
 		"main.js"
 	],

--- a/test/integration/verify/fixtures/js-es7/origami.json
+++ b/test/integration/verify/fixtures/js-es7/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/js-es7/package.json
+++ b/test/integration/verify/fixtures/js-es7/package.json
@@ -1,5 +1,7 @@
 {
 	"name": "test-component",
+	"description": "for a fixture",
+	"keywords": [],
 	"main": [
 		"main.js"
 	],

--- a/test/integration/verify/fixtures/js-invalid/origami.json
+++ b/test/integration/verify/fixtures/js-invalid/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/js-invalid/package.json
+++ b/test/integration/verify/fixtures/js-invalid/package.json
@@ -1,12 +1,12 @@
 {
   "name": "js-invalid",
+  "description": "for a fixture",
+  "keywords": [],
   "version": "1.0.0",
-  "description": "test component",
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/js-npm-dependency/origami.json
+++ b/test/integration/verify/fixtures/js-npm-dependency/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/js-npm-dependency/package.json
+++ b/test/integration/verify/fixtures/js-npm-dependency/package.json
@@ -1,5 +1,7 @@
 {
   "name": "test-component",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "main.js",
   "type": "module",
   "dependencies": {

--- a/test/integration/verify/fixtures/no-js-or-sass/origami.json
+++ b/test/integration/verify/fixtures/no-js-or-sass/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/no-js-or-sass/package.json
+++ b/test/integration/verify/fixtures/no-js-or-sass/package.json
@@ -1,12 +1,12 @@
 {
   "name": "no-js-or-sass",
   "version": "1.0.0",
-  "description": "test component",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/no-readme/origami.json
+++ b/test/integration/verify/fixtures/no-readme/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/no-readme/package.json
+++ b/test/integration/verify/fixtures/no-readme/package.json
@@ -1,12 +1,12 @@
 {
   "name": "no-readme",
   "version": "1.0.0",
-  "description": "",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/origami.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
@@ -1,5 +1,7 @@
 {
 	"name": "test-component",
+	"description": "for a fixture",
+	"keywords": [],
 	"main": [],
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/readme-invalid-name/origami.json
+++ b/test/integration/verify/fixtures/readme-invalid-name/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/readme-invalid-name/package.json
+++ b/test/integration/verify/fixtures/readme-invalid-name/package.json
@@ -1,12 +1,12 @@
 {
   "name": "no-readme",
   "version": "1.0.0",
-  "description": "",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/readme-invalid/origami.json
+++ b/test/integration/verify/fixtures/readme-invalid/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/readme-invalid/package.json
+++ b/test/integration/verify/fixtures/readme-invalid/package.json
@@ -1,12 +1,12 @@
 {
   "name": "invalid-readme",
   "version": "1.0.0",
-  "description": "",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/readme-valid-lowercase/origami.json
+++ b/test/integration/verify/fixtures/readme-valid-lowercase/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/readme-valid-lowercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-lowercase/package.json
@@ -1,12 +1,12 @@
 {
   "name": "no-readme",
   "version": "1.0.0",
-  "description": "",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/readme-valid-uppercase/origami.json
+++ b/test/integration/verify/fixtures/readme-valid-uppercase/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/readme-valid-uppercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-uppercase/package.json
@@ -1,12 +1,12 @@
 {
   "name": "no-readme",
   "version": "1.0.0",
-  "description": "",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/sass-bower-dependency/origami.json
+++ b/test/integration/verify/fixtures/sass-bower-dependency/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/sass-bower-dependency/package.json
+++ b/test/integration/verify/fixtures/sass-bower-dependency/package.json
@@ -1,5 +1,7 @@
 {
   "name": "test-component",
+  "description": "for a fixture",
+	"keywords": [],
   "main": [
     "main.scss"
   ],

--- a/test/integration/verify/fixtures/sass-custom-config/origami.json
+++ b/test/integration/verify/fixtures/sass-custom-config/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/sass-custom-config/package.json
+++ b/test/integration/verify/fixtures/sass-custom-config/package.json
@@ -1,12 +1,12 @@
 {
   "name": "sass-custom-config",
   "version": "1.0.0",
-  "description": "test component",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",

--- a/test/integration/verify/fixtures/sass-invalid/origami.json
+++ b/test/integration/verify/fixtures/sass-invalid/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/sass-invalid/package.json
+++ b/test/integration/verify/fixtures/sass-invalid/package.json
@@ -1,12 +1,12 @@
 {
   "name": "sass-invalid",
   "version": "1.0.0",
-  "description": "test component",
+  "description": "for a fixture",
+  "keywords": [],
   "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/test/integration/verify/fixtures/sass-npm-dependency/origami.json
+++ b/test/integration/verify/fixtures/sass-npm-dependency/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/sass-npm-dependency/package.json
+++ b/test/integration/verify/fixtures/sass-npm-dependency/package.json
@@ -1,5 +1,7 @@
 {
   "name": "test-component",
+  "description": "for a fixture",
+  "keywords": [],
   "type": "module",
   "dependencies": {
     "o-test-component": "1.0.7"

--- a/test/integration/verify/fixtures/sass/origami.json
+++ b/test/integration/verify/fixtures/sass/origami.json
@@ -1,6 +1,4 @@
 {
-	"description": "for a fixture",
-	"keywords": [],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": "2.0",

--- a/test/integration/verify/fixtures/sass/package.json
+++ b/test/integration/verify/fixtures/sass/package.json
@@ -1,4 +1,6 @@
 {
 	"name": "test-component",
+	"description": "for a fixture",
+	"keywords": [],
 	"type": "module"
 }

--- a/test/unit/fixtures/o-test/package.json
+++ b/test/unit/fixtures/o-test/package.json
@@ -1,16 +1,12 @@
 {
-  "name": "js-custom-eslint",
+  "name": "o-test",
   "version": "1.0.0",
   "description": "for a fixture",
+	"keywords": [],
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
-  "license": "ISC",
-  "type": "module",
-  "devDependencies": {
-    "eslint-config-origami-component": "^1.1.1"
-  }
+  "license": "ISC"
 }

--- a/test/unit/helpers/files.test.js
+++ b/test/unit/helpers/files.test.js
@@ -32,24 +32,14 @@ describe('Files helper', function () {
 	it('should return module name', function () {
 		return files.getComponentName()
 			.then(name => {
-				proclaim.equal(name, '');
-			})
-			.then(() => {
-				fs.writeFileSync('package.json', JSON.stringify({
-					name: 'o-test'
-				}), 'utf8');
-				return files.getComponentName()
-					.then(name => {
-						proclaim.equal(name, 'o-test');
-						fs.unlinkSync(path.resolve(filesTestPath, 'package.json'));
-					});
+				proclaim.equal(name, 'o-test');
 			});
 	});
 
 	it('should not return package namespace in module name', function () {
 		return files.getComponentName()
 			.then(name => {
-				proclaim.equal(name, '');
+				proclaim.equal(name, 'o-test');
 			})
 			.then(() => {
 				fs.writeFileSync('package.json', JSON.stringify({

--- a/test/unit/tasks/verify-origami-json.test.js
+++ b/test/unit/tasks/verify-origami-json.test.js
@@ -102,7 +102,6 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'A non-empty description property is required\n' +
 						'The origamiType property needs to be set to either "imageset", "module" or "service"\n' +
 						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.\n' +
 						'The support property must be an email or url to an issue tracker for this module\n' +
@@ -121,7 +120,7 @@ describe('verify-origami-json', function () {
 				proclaim.calledOnce(console.log);
 				proclaim.calledWithExactly(
 					console.log,
-					`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AA non-empty description property is required%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+					`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 				);
 			}
 		});
@@ -136,13 +135,12 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'A non-empty description property is required\n\n' +
 						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AA non-empty description property is required%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});
@@ -157,13 +155,12 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'A non-empty description property is required\n\n' +
 						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AA non-empty description property is required%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});
@@ -178,13 +175,12 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'A non-empty description property is required\n\n' +
 						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AA non-empty description property is required%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0A'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.'%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0A'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.'%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});
@@ -386,7 +382,7 @@ describe('verify-origami-json', function () {
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AA non-empty description property is required%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -1,0 +1,254 @@
+/* eslint-env mocha */
+'use strict';
+
+const mockery = require('mockery');
+const proclaim = require('proclaim');
+const sinon = require('sinon');
+sinon.assert.expose(proclaim, {
+	includeFail: false,
+	prefix: ''
+});
+const process = require('process');
+const fs = require('fs-extra');
+const path = require('path');
+
+const obtPath = process.cwd();
+const oTestPath = 'test/unit/fixtures/o-test';
+const pathSuffix = '-verify';
+const verifyTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
+
+describe('verify-package-json', function () {
+	let verifyPackageJson;
+	const originalConsole = global.console;
+	let console;
+	beforeEach(function() {
+		mockery.enable({
+			useCleanCache: true,
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		});
+		console = {
+			log: sinon.stub(),
+			warn: sinon.stub(),
+			error: sinon.stub()
+		};
+		mockery.registerMock('is-ci', true);
+		process.env.CI = true;
+		global.console = console;
+		verifyPackageJson = require('../../../lib/tasks/verify-package-json');
+		fs.copySync(path.resolve(obtPath, oTestPath), verifyTestPath);
+		process.chdir(verifyTestPath);
+		fs.writeFileSync('src/scss/verify.scss', '$color: #ccc;\n\np {\n  color: $color!important ;\n}\n', 'utf8');
+		fs.writeFileSync('src/js/verify.js', 'const test = \'We live in financial times\';\n');
+	});
+
+	afterEach(function () {
+		global.console = originalConsole;
+		mockery.resetCache();
+		mockery.deregisterAll();
+		mockery.disable();
+		process.chdir(obtPath);
+		fs.removeSync(path.resolve(obtPath, verifyTestPath));
+	});
+
+	describe('default title', () => {
+		it('should be "Verifying your package.json"', () => {
+			proclaim.equal(verifyPackageJson().title, 'Verifying your package.json');
+		});
+	});
+
+	describe('skip', () => {
+		it('should return true if the file does not exist', () => {
+			fs.removeSync(path.join(process.cwd(), '/package.json'));
+			proclaim.ok(verifyPackageJson().skip());
+		});
+
+		it('should return a helpful message if the file does not exist', function() {
+			fs.removeSync(path.join(process.cwd(), '/package.json'));
+			return verifyPackageJson().skip()
+				.then(skipped => {
+					proclaim.equal(skipped, `No package.json file found. To make this an origami component, create a file at ${path.join(process.cwd(), '/package.json')} following the format defined at: https://origami.ft.com/spec/v2/components/#package-management`);
+				});
+		});
+
+		it('should return a falsey value if the file does exist', function () {
+			return verifyPackageJson().skip()
+				.then(skipped => {
+					proclaim.notOk(skipped);
+				});
+		});
+	});
+
+	describe('task', function () {
+		it('should run package.json check successfully', function () {
+			return verifyPackageJson().task().
+				then(function (verifiedOrigamiJson) {
+					proclaim.equal(verifiedOrigamiJson.length, 0);
+				});
+		});
+
+		it('should not write to the output a github annotation if package.json has no issues', async () => {
+			// there is no js in the scss folder to verify
+			process.chdir('./src/scss');
+			await verifyPackageJson().task();
+			proclaim.notCalled(console.log);
+		});
+
+		it('should fail with an empty package.json', function () {
+			fs.writeFileSync('package.json', JSON.stringify({}), 'utf8');
+
+			return verifyPackageJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'A description property is required. It must be a string which describes the component.\n' +
+						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+				});
+		});
+
+		it('should write to the output a github annotation if empty package.json', async function() {
+			try {
+				fs.writeFileSync('package.json', JSON.stringify({}), 'utf8');
+				await verifyPackageJson().task();
+			} catch (e) {
+				proclaim.ok(e, `Unexpected error: ${e.message}`);
+				proclaim.calledOnce(console.log);
+				proclaim.calledWithExactly(
+					console.log,
+					`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+				);
+			}
+		});
+
+		it('should fail if missing description property', function () {
+			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			delete origamiJSON.description;
+			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyPackageJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'A description property is required. It must be a string which describes the component.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.calledWithExactly(
+						console.log,
+						`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+					);
+				});
+		});
+
+		it('should fail if description property is an empty string', function () {
+			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			origamiJSON.description = '';
+			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyPackageJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'A description property is required. It must be a string which describes the component.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.calledWithExactly(
+						console.log,
+						`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+					);
+				});
+		});
+
+		it('should fail if description property is a string containing only spaces', function () {
+			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			origamiJSON.description = '      ';
+			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyPackageJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'A description property is required. It must be a string which describes the component.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.calledWithExactly(
+						console.log,
+						`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+					);
+				});
+		});
+
+		it('should fail if missing keywords property', function () {
+			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			delete origamiJSON.keywords;
+			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyPackageJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.calledWithExactly(
+						console.log,
+						`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+					);
+				});
+		});
+
+		it('should fail if keywords property contains an empty string', function () {
+			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			origamiJSON.keywords = [''];
+			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyPackageJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.calledWithExactly(
+						console.log,
+						`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+					);
+				});
+		});
+
+		it('should fail if keywords property contains a string containing only spaces', function () {
+			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			origamiJSON.keywords = ['      '];
+			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+
+			return verifyPackageJson().task()
+				.catch(function (verifiedOrigamiJson) {
+					proclaim.equal(
+						verifiedOrigamiJson.message,
+						'Failed linting:\n\n' +
+						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.calledWithExactly(
+						console.log,
+						`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+					);
+				});
+		});
+
+
+	});
+});


### PR DESCRIPTION
This was agreed by the team via this proposal -- Financial-Times/origami#119

It has already been added to the draft v2 spec -- https://github.com/Financial-Times/origami-website/pull/343