### PR TITLE
Improve tests for verify-package-json

### DIFF
--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -98,29 +98,29 @@ describe('verify-package-json', function () {
 			fs.writeFileSync('package.json', JSON.stringify({}), 'utf8');
 
 			let errored;
-				try {
-					await verifyPackageJson().task();
-					errored = false;
-				} catch (error) {
-					errored = true;
-					proclaim.equal(
-						error.message,
-						'Failed linting:\n\n' +
+			try {
+				await verifyPackageJson().task();
+				errored = false;
+			} catch (error) {
+				errored = true;
+				proclaim.equal(
+					error.message,
+					'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n' +
 						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
-					);
-					proclaim.calledOnce(console.log);
+				);
+				proclaim.calledOnce(console.log);
 
-					proclaim.deepStrictEqual(
-						console.log.lastCall.args,
-						[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
-					);
-				}
+				proclaim.deepStrictEqual(
+					console.log.lastCall.args,
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+				);
+			}
 
-				if (!errored) {
-					proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
-				}
+			if (!errored) {
+				proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+			}
 		});
 
 		it('should write to the output a github annotation if empty package.json', async function() {

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -82,8 +82,8 @@ describe('verify-package-json', function () {
 	describe('task', function () {
 		it('should run package.json check successfully', function () {
 			return verifyPackageJson().task().
-				then(function (verifiedOrigamiJson) {
-					proclaim.equal(verifiedOrigamiJson.length, 0);
+				then(function (verifiedpackageJson) {
+					proclaim.equal(verifiedpackageJson.length, 0);
 				});
 		});
 
@@ -98,9 +98,9 @@ describe('verify-package-json', function () {
 			fs.writeFileSync('package.json', JSON.stringify({}), 'utf8');
 
 			return verifyPackageJson().task()
-				.catch(function (verifiedOrigamiJson) {
+				.catch(function (verifiedpackageJson) {
 					proclaim.equal(
-						verifiedOrigamiJson.message,
+						verifiedpackageJson.message,
 						'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n' +
 						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
@@ -124,14 +124,14 @@ describe('verify-package-json', function () {
 		});
 
 		it('should fail if missing description property', function () {
-			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
-			delete origamiJSON.description;
-			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+			const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			delete packageJSON.description;
+			fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
 
 			return verifyPackageJson().task()
-				.catch(function (verifiedOrigamiJson) {
+				.catch(function (verifiedpackageJson) {
 					proclaim.equal(
-						verifiedOrigamiJson.message,
+						verifiedpackageJson.message,
 						'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
@@ -145,14 +145,14 @@ describe('verify-package-json', function () {
 		});
 
 		it('should fail if description property is an empty string', function () {
-			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
-			origamiJSON.description = '';
-			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+			const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			packageJSON.description = '';
+			fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
 
 			return verifyPackageJson().task()
-				.catch(function (verifiedOrigamiJson) {
+				.catch(function (verifiedpackageJson) {
 					proclaim.equal(
-						verifiedOrigamiJson.message,
+						verifiedpackageJson.message,
 						'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
@@ -166,14 +166,14 @@ describe('verify-package-json', function () {
 		});
 
 		it('should fail if description property is a string containing only spaces', function () {
-			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
-			origamiJSON.description = '      ';
-			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+			const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			packageJSON.description = '      ';
+			fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
 
 			return verifyPackageJson().task()
-				.catch(function (verifiedOrigamiJson) {
+				.catch(function (verifiedpackageJson) {
 					proclaim.equal(
-						verifiedOrigamiJson.message,
+						verifiedpackageJson.message,
 						'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
@@ -187,14 +187,14 @@ describe('verify-package-json', function () {
 		});
 
 		it('should fail if missing keywords property', function () {
-			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
-			delete origamiJSON.keywords;
-			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+			const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			delete packageJSON.keywords;
+			fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
 
 			return verifyPackageJson().task()
-				.catch(function (verifiedOrigamiJson) {
+				.catch(function (verifiedpackageJson) {
 					proclaim.equal(
-						verifiedOrigamiJson.message,
+						verifiedpackageJson.message,
 						'Failed linting:\n\n' +
 						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
@@ -208,14 +208,14 @@ describe('verify-package-json', function () {
 		});
 
 		it('should fail if keywords property contains an empty string', function () {
-			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
-			origamiJSON.keywords = [''];
-			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+			const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			packageJSON.keywords = [''];
+			fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
 
 			return verifyPackageJson().task()
-				.catch(function (verifiedOrigamiJson) {
+				.catch(function (verifiedpackageJson) {
 					proclaim.equal(
-						verifiedOrigamiJson.message,
+						verifiedpackageJson.message,
 						'Failed linting:\n\n' +
 						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
@@ -229,14 +229,14 @@ describe('verify-package-json', function () {
 		});
 
 		it('should fail if keywords property contains a string containing only spaces', function () {
-			const origamiJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
-			origamiJSON.keywords = ['      '];
-			fs.writeFileSync('package.json', JSON.stringify(origamiJSON), 'utf8');
+			const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+			packageJSON.keywords = ['      '];
+			fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
 
 			return verifyPackageJson().task()
-				.catch(function (verifiedOrigamiJson) {
+				.catch(function (verifiedpackageJson) {
 					proclaim.equal(
-						verifiedOrigamiJson.message,
+						verifiedpackageJson.message,
 						'Failed linting:\n\n' +
 						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -83,7 +83,6 @@ describe('verify-package-json', function () {
 		it('should run package.json check successfully', function () {
 			return verifyPackageJson().task().
 				then(function (verifiedpackageJson) {
-					console.log({verifiedpackageJson})
 					proclaim.equal(verifiedpackageJson.length, 0);
 				});
 		});

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -170,9 +170,9 @@ describe('verify-package-json', function () {
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
-				proclaim.calledWithExactly(
-					console.log,
-					`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+				proclaim.deepStrictEqual(
+					console.log.lastCall.args,
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
 				);
 			}
 
@@ -199,9 +199,9 @@ describe('verify-package-json', function () {
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
-				proclaim.calledWithExactly(
-					console.log,
-					`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+				proclaim.deepStrictEqual(
+					console.log.lastCall.args,
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
 				);
 			}
 
@@ -228,9 +228,9 @@ describe('verify-package-json', function () {
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
-				proclaim.calledWithExactly(
-					console.log,
-					`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+				proclaim.deepStrictEqual(
+					console.log.lastCall.args,
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
 				);
 			}
 
@@ -257,9 +257,9 @@ describe('verify-package-json', function () {
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
-				proclaim.calledWithExactly(
-					console.log,
-					`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+				proclaim.deepStrictEqual(
+					console.log.lastCall.args,
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
 				);
 			}
 
@@ -286,9 +286,9 @@ describe('verify-package-json', function () {
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
-				proclaim.calledWithExactly(
-					console.log,
-					`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+				proclaim.deepStrictEqual(
+					console.log.lastCall.args,
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
 				);
 			}
 
@@ -315,9 +315,9 @@ describe('verify-package-json', function () {
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
-				proclaim.calledWithExactly(
-					console.log,
-					`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`
+				proclaim.deepStrictEqual(
+					console.log.lastCall.args,
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
 				);
 			}
 
@@ -325,9 +325,6 @@ describe('verify-package-json', function () {
 				proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
 			}
 		});
-				});
-		});
-
 
 	});
 });

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -82,8 +82,8 @@ describe('verify-package-json', function () {
 	describe('task', function () {
 		it('should run package.json check successfully', function () {
 			return verifyPackageJson().task().
-				then(function (verifiedpackageJson) {
-					proclaim.equal(verifiedpackageJson.length, 0);
+				then(function (verifiedPackageJson) {
+					proclaim.equal(verifiedPackageJson.length, 0);
 				});
 		});
 


### PR DESCRIPTION
For the scenarios where we were testing an invalid package.json file, if verify-package-json incorrectly validated the package.json, the test would not fail.

I've refactored those tests to now check if verify-package-json has returned a rejected promise, and if it has not, to fail.

I've also refactored the code to use proclaim.deepStrictEqual instead of proclaim.calledWithExactly because deepStrictEqual will the expected value and actual value if they are not the same, whereas calledWithExactly only states they are not the same, which I did not find useful at all because I couldn't tell where/how they were different.