### PR TITLE
Add validation for package.json.name field

### DIFF
--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -9,6 +9,11 @@ const isCI = require('is-ci');
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
 
+/**
+ * Checks whether description conforms to the origami package.json description specification.
+ * @param {any} description The value to check
+ * @returns {Boolean} Whether `description` conforms to the origami package.json description specification.
+ */
 function validDescription(description) {
 	if (typeof description === 'string' && description.trim().length > 0) {
 		return true;
@@ -17,6 +22,11 @@ function validDescription(description) {
 	}
 }
 
+/**
+ * Checks whether keywords conforms to the origami package.json keywords specification.
+ * @param {any} keywords The value to check
+ * @returns {Boolean} Whether `keywords` conforms to the origami package.json keywords specification.
+ */
 function validKeywords(keywords) {
 	if (Array.isArray(keywords)) {
 		const valid = keywords.every(keyword => {

--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -9,6 +9,25 @@ const isCI = require('is-ci');
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
 
+function validDescription(description) {
+	if (typeof description === 'string' && description.trim().length > 0) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function validKeywords(keywords) {
+	if (Array.isArray(keywords)) {
+		const valid = keywords.every(keyword => {
+			return typeof keyword === 'string' && keyword.trim().length > 0;
+		});
+		return valid;
+	} else {
+		return false;
+	}
+}
+
 function packageJson(config) {
 	const result = [];
 
@@ -19,18 +38,10 @@ function packageJson(config) {
 				return readFile(packageJsonPath, 'utf8')
 					.then(file => {
 						const packageJson = JSON.parse(file);
-						if (typeof packageJson.description === 'string') {
-							if (packageJson.description.trim().length === 0) {
-								result.push('A description property is required. It must be a string which describes the component.');
-							}
-						} else {
+						if (!validDescription(packageJson.description)) {
 							result.push('A description property is required. It must be a string which describes the component.');
 						}
-						if (Array.isArray(packageJson.keywords)) {
-							if (packageJson.keywords.some(keyword => typeof keyword !== 'string' || keyword.trim().length === 0)) {
-								result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
-							}
-						} else {
+						if (!validKeywords(packageJson.keywords)) {
 							result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
 						}
 

--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const denodeify = require('util').promisify;
 const isCI = require('is-ci');
+const validateNpmPackageName = require('validate-npm-package-name');
 
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
@@ -38,6 +39,28 @@ function validKeywords(keywords) {
 	}
 }
 
+/**
+ * Checks an npm component name conforms to the origami package.json specification.
+ * @param {String} name An npm component name.
+ * @returns {Boolean} Whether the name parameter is valid according to origami package.json specification.
+ */
+function validName(name) {
+	if (typeof name === 'string' && name.startsWith('@financial-times/') && isValidNpmName(name)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+/**
+ * Checks an npm component name conforms to the npmjs package.json specification.
+ * @param {String} name An npm component name.
+ * @returns {Boolean} Whether the name parameter is valid according to npmjs package.json specification.
+ */
+function isValidNpmName(name) {
+	return validateNpmPackageName(name).validForNewPackages;
+}
+
 function packageJson(config) {
 	const result = [];
 
@@ -53,6 +76,9 @@ function packageJson(config) {
 						}
 						if (!validKeywords(packageJson.keywords)) {
 							result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
+						}
+						if (!validName(packageJson.name)) {
+							result.push('The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.');
 						}
 
 						if (result.length > 0) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -62,6 +62,7 @@
 				"strip-ansi": "^6.0.0",
 				"stylelint": "^13.8.0",
 				"update-notifier": "^4.1.0",
+				"validate-npm-package-name": "^3.0.0",
 				"vfile": "^4.1.1",
 				"vfile-reporter": "^6.0.1"
 			},
@@ -3273,6 +3274,11 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+		},
+		"node_modules/builtins": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
 		},
 		"node_modules/bytes": {
 			"version": "3.1.0",
@@ -17330,6 +17336,14 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
+		"node_modules/validate-npm-package-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+			"dependencies": {
+				"builtins": "^1.0.3"
+			}
+		},
 		"node_modules/vfile": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
@@ -20580,6 +20594,11 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+		},
+		"builtins": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
 		},
 		"bytes": {
 			"version": "3.1.0",
@@ -31160,6 +31179,14 @@
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"validate-npm-package-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+			"requires": {
+				"builtins": "^1.0.3"
 			}
 		},
 		"vfile": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"strip-ansi": "^6.0.0",
 		"stylelint": "^13.8.0",
 		"update-notifier": "^4.1.0",
+		"validate-npm-package-name": "^3.0.0",
 		"vfile": "^4.1.1",
 		"vfile-reporter": "^6.0.1"
 	},

--- a/test/integration/demo/fixtures/multiple-demos/package.json
+++ b/test/integration/demo/fixtures/multiple-demos/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "o-multiple-demos",
+  "name": "@financial-times/o-multiple-demos",
   "description": "a fixture to test the demo command of origami-build-tools",
   "main": "main.js"
 }

--- a/test/integration/install/fixtures/no-npm-dependencies/package-lock.json
+++ b/test/integration/install/fixtures/no-npm-dependencies/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "no-dependencies",
+  "name": "@financial-times/no-dependencies",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "no-dependencies"
+      "name": "@financial-times/no-dependencies"
     }
   }
 }

--- a/test/integration/install/fixtures/no-npm-dependencies/package.json
+++ b/test/integration/install/fixtures/no-npm-dependencies/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "no-dependencies"
+  "name": "@financial-times/no-dependencies"
 }

--- a/test/integration/install/fixtures/with-npm-dependencies/package-lock.json
+++ b/test/integration/install/fixtures/with-npm-dependencies/package-lock.json
@@ -1,9 +1,10 @@
 {
-	"name": "with-npm-dependencies",
+	"name": "@financial-times/with-npm-dependencies",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "@financial-times/with-npm-dependencies",
 			"dependencies": {
 				"lodash": "*"
 			}

--- a/test/integration/install/fixtures/with-npm-dependencies/package.json
+++ b/test/integration/install/fixtures/with-npm-dependencies/package.json
@@ -1,4 +1,5 @@
 {
+	"name": "@financial-times/with-npm-dependencies",
 	"type": "module",
 	"dependencies": {
 		"lodash": "*"

--- a/test/integration/test/fixtures/with-npm-dependency-installed/package-lock.json
+++ b/test/integration/test/fixtures/with-npm-dependency-installed/package-lock.json
@@ -1,10 +1,10 @@
 {
-    "name": "test-component",
+    "name": "@financial-times/test-component",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "test-component",
+            "name": "@financial-times/test-component",
             "dependencies": {
                 "o-test-component": "Financial-Times/o-test-component#v1.0.33"
             }

--- a/test/integration/test/fixtures/with-npm-dependency-installed/package.json
+++ b/test/integration/test/fixtures/with-npm-dependency-installed/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "test-component",
+    "name": "@financial-times/test-component",
     "type": "module",
     "dependencies": {
         "o-test-component": "Financial-Times/o-test-component#v1.0.33"

--- a/test/integration/verify/fixtures/js-custom-eslint/package.json
+++ b/test/integration/verify/fixtures/js-custom-eslint/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-custom-eslint",
+  "name": "@financial-times/js-custom-eslint",
   "version": "1.0.0",
   "description": "for a fixture",
   "main": "main.js",

--- a/test/integration/verify/fixtures/js-es5/package.json
+++ b/test/integration/verify/fixtures/js-es5/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-component",
+	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
 	"main": [

--- a/test/integration/verify/fixtures/js-es6/package.json
+++ b/test/integration/verify/fixtures/js-es6/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-component",
+	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
 	"main": [

--- a/test/integration/verify/fixtures/js-es7/package.json
+++ b/test/integration/verify/fixtures/js-es7/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-component",
+	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
 	"main": [

--- a/test/integration/verify/fixtures/js-invalid/package.json
+++ b/test/integration/verify/fixtures/js-invalid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-invalid",
+  "name": "@financial-times/js-invalid",
   "description": "for a fixture",
   "keywords": [],
   "version": "1.0.0",

--- a/test/integration/verify/fixtures/js-npm-dependency/package.json
+++ b/test/integration/verify/fixtures/js-npm-dependency/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-component",
+  "name": "@financial-times/test-component",
   "description": "for a fixture",
   "keywords": [],
   "main": "main.js",

--- a/test/integration/verify/fixtures/no-js-or-sass/package.json
+++ b/test/integration/verify/fixtures/no-js-or-sass/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "no-js-or-sass",
+  "name": "@financial-times/no-js-or-sass",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/no-readme/package.json
+++ b/test/integration/verify/fixtures/no-readme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "no-readme",
+  "name": "@financial-times/no-readme",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-component",
+	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
 	"main": [],

--- a/test/integration/verify/fixtures/readme-invalid-name/package.json
+++ b/test/integration/verify/fixtures/readme-invalid-name/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "no-readme",
+  "name": "@financial-times/no-readme",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/readme-invalid/package.json
+++ b/test/integration/verify/fixtures/readme-invalid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "invalid-readme",
+  "name": "@financial-times/invalid-readme",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/readme-valid-lowercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-lowercase/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "no-readme",
+  "name": "@financial-times/no-readme",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/readme-valid-uppercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-uppercase/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "no-readme",
+  "name": "@financial-times/no-readme",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/sass-custom-config/package.json
+++ b/test/integration/verify/fixtures/sass-custom-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sass-custom-config",
+  "name": "@financial-times/sass-custom-config",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/sass-invalid/package.json
+++ b/test/integration/verify/fixtures/sass-invalid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sass-invalid",
+  "name": "@financial-times/sass-invalid",
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],

--- a/test/integration/verify/fixtures/sass-npm-dependency/package.json
+++ b/test/integration/verify/fixtures/sass-npm-dependency/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-component",
+  "name": "@financial-times/test-component",
   "description": "for a fixture",
   "keywords": [],
   "type": "module",

--- a/test/integration/verify/fixtures/sass/package.json
+++ b/test/integration/verify/fixtures/sass/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-component",
+	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
 	"type": "module"

--- a/test/integration/verify/verify.test.js
+++ b/test/integration/verify/verify.test.js
@@ -71,7 +71,7 @@ describe('obt verify', function () {
 
 			it('should warn', function () {
 				return execa(obt, ['verify']).then(output => {
-					proclaim.include(output.stdout, 'expected "invalid-readme", got "not-the-component-name"');
+					proclaim.include(output.stdout, 'expected "@financial-times/invalid-readme", got "not-the-component-name"');
 				});
 			});
 		});

--- a/test/unit/fixtures/o-test/package.json
+++ b/test/unit/fixtures/o-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "o-test",
+  "name": "@financial-times/o-test",
   "version": "1.0.0",
   "description": "for a fixture",
 	"keywords": [],

--- a/test/unit/fixtures/verify/package-lock.json
+++ b/test/unit/fixtures/verify/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "verify",
+  "name": "@financial-times/verify",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/test/unit/fixtures/verify/src/js/error/package-lock.json
+++ b/test/unit/fixtures/verify/src/js/error/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "error",
+  "name": "@financial-times/error",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/test/unit/fixtures/verify/src/js/error/package.json
+++ b/test/unit/fixtures/verify/src/js/error/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@financial-times/error",
   "devDependencies": {
     "eslint-config-origami-component": "^2.1.0"
   }

--- a/test/unit/fixtures/verify/src/js/warning/package-lock.json
+++ b/test/unit/fixtures/verify/src/js/warning/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "warning",
+  "name": "@financial-times/warning",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/test/unit/fixtures/verify/src/js/warning/package.json
+++ b/test/unit/fixtures/verify/src/js/warning/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@financial-times/warning",
   "devDependencies": {
     "eslint-config-origami-component": "^2.1.0"
   }

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -107,14 +107,15 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n' +
-						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n' +
+						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -136,13 +137,14 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n' +
-						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n' +
+						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -194,8 +196,8 @@ describe('verify-package-json', function () {
 				proclaim.equal(
 					error.message,
 					'Failed linting:\n\n' +
-						'A description property is required. It must be a string which describes the component.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'A description property is required. It must be a string which describes the component.\n\n' +
+					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
@@ -223,13 +225,13 @@ describe('verify-package-json', function () {
 				proclaim.equal(
 					error.message,
 					'Failed linting:\n\n' +
-						'A description property is required. It must be a string which describes the component.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'A description property is required. It must be a string which describes the component.\n\n' +
+					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -252,13 +254,13 @@ describe('verify-package-json', function () {
 				proclaim.equal(
 					error.message,
 					'Failed linting:\n\n' +
-						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -281,13 +283,13 @@ describe('verify-package-json', function () {
 				proclaim.equal(
 					error.message,
 					'Failed linting:\n\n' +
-						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -310,13 +312,13 @@ describe('verify-package-json', function () {
 				proclaim.equal(
 					error.message,
 					'Failed linting:\n\n' +
-						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
+					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -324,6 +326,137 @@ describe('verify-package-json', function () {
 				proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
 			}
 		});
+
+		context('the name property', function(){
+
+			it('should fail if property is missing', async function () {
+				const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+				delete packageJSON.name;
+				fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+				let errored;
+				try {
+					await verifyPackageJson().task();
+					errored = false;
+				} catch (error) {
+					errored = true;
+					proclaim.equal(
+						error.message,
+						'Failed linting:\n\n' +
+						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.deepStrictEqual(
+						console.log.lastCall.args,
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					);
+				}
+
+				if (!errored) {
+					proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+				}
+			});
+
+			it('should fail if property contains an empty string', async function () {
+				const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+				packageJSON.name = '';
+				fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+				let errored;
+				try {
+					await verifyPackageJson().task();
+					errored = false;
+				} catch (error) {
+					errored = true;
+					proclaim.equal(
+						error.message,
+						'Failed linting:\n\n' +
+						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.deepStrictEqual(
+						console.log.lastCall.args,
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					);
+				}
+
+				if (!errored) {
+					proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+				}
+			});
+
+			it('should fail if property does not conform to the npmjs specification', async function () {
+				const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+				packageJSON.name = '@financial-times/Hello_W@rld!';
+				fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+				let errored;
+				try {
+					await verifyPackageJson().task();
+					errored = false;
+				} catch (error) {
+					errored = true;
+					proclaim.equal(
+						error.message,
+						'Failed linting:\n\n' +
+						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.deepStrictEqual(
+						console.log.lastCall.args,
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					);
+				}
+
+				if (!errored) {
+					proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+				}
+			});
+
+			it('should fail if it is not within the `@financial-times` namespace', async function () {
+				const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+				packageJSON.name = 'o-test-component';
+				fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+				let errored;
+				try {
+					await verifyPackageJson().task();
+					errored = false;
+				} catch (error) {
+					errored = true;
+					proclaim.equal(
+						error.message,
+						'Failed linting:\n\n' +
+						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					);
+					proclaim.calledOnce(console.log);
+					proclaim.deepStrictEqual(
+						console.log.lastCall.args,
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					);
+				}
+
+				if (!errored) {
+					proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+				}
+			});
+
+			it('should pass if it is within the `@financial-times` namespace and conforms to the npmjs specification', async function () {
+				const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+				packageJSON.name = '@financial-times/o-test-component';
+				fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+				await verifyPackageJson().task();
+				proclaim.notCalled(console.log);
+			});
+
+		});
+
+
 
 	});
 });


### PR DESCRIPTION
The component v2 specification states that the name field is required and must use the `@financial-times` scope. This pull-request updates the verify task to ensure that the component being tested adheres to these rules.

I've quoted below the parts of the specification this is testing.

>Origami components **must** include a `package.json` manifest, **must** be installable through the <a href="https://npmjs.com/" class="o-typography-link--external">npm package manager</a>, and **must** be published under one of the following <a href="https://docs.npmjs.com/cli/v7/using-npm/scope" class="o-typography-link--external">npm scopes</a>:
>  - `@financial-times`
> 
> ...
>
>- It **must** include a <a href="https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name">`name`</a> property set to the package name, e.g. `@financial-times/o-typography`.

Those came from the spec v2 pull-request -- https://github.com/Financial-Times/origami-website/pull/273/files#diff-5ebc2f3b798414ec905f3fdceb910557607b8d779a56bf1ce09ad48e32fd085aR88