### PR TITLE
Add validation for package.json.browser field

### DIFF
--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -40,6 +40,33 @@ function validKeywords(keywords) {
 }
 
 /**
+ * Checks whether browser conforms to the origami package.json browser specification.
+ * @param {any} manifest The manifest to check
+ * @param {string} workingDirectory The directory which contains the component to check
+ * @returns {string|void} If valid, returns undefined, otherwise returns a string which explains why it is not valid
+ */
+function validJavaScriptEntryPoint(manifest, workingDirectory) {
+	const mainJavaScriptFileExists = fs.existsSync(path.join(workingDirectory, '/main.js'));
+	if (mainJavaScriptFileExists) {
+		if (typeof manifest.browser === 'string' && manifest.browser === 'main.js') {
+			// The file `main.js` exists and package.json.browser is set to `"main.js"`
+			return undefined;
+		} else {
+			// The file `main.js` exists and package.json.browser is not set to `"main.js"`
+			return 'Because the file `main.js` exists, the `browser` property is required. It must have the value `"main.js"`.';
+		}
+	} else {
+		if (Object.hasOwnProperty.call(manifest, 'browser')) {
+			// The file `main.js` not exist and package.json.browser does exist
+			return 'Because the file `main.js` does not exist, the `browser` property must not be set.';
+		} else {
+			// The file `main.js` does not exists and package.json.browser does not exist
+			return undefined;
+		}
+	}
+}
+
+/**
  * Checks an npm component name conforms to the origami package.json specification.
  * @param {String} name An npm component name.
  * @returns {Boolean} Whether the name parameter is valid according to origami package.json specification.
@@ -61,41 +88,41 @@ function isValidNpmName(name) {
 	return validateNpmPackageName(name).validForNewPackages;
 }
 
-function packageJson(config) {
+async function packageJson(config) {
 	const result = [];
-
 	const packageJsonPath = path.join(config.cwd, '/package.json');
-	return fileExists(packageJsonPath)
-		.then(exists => {
-			if (exists) {
-				return readFile(packageJsonPath, 'utf8')
-					.then(file => {
-						const packageJson = JSON.parse(file);
-						if (!validDescription(packageJson.description)) {
-							result.push('A description property is required. It must be a string which describes the component.');
-						}
-						if (!validKeywords(packageJson.keywords)) {
-							result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
-						}
-						if (!validName(packageJson.name)) {
-							result.push('The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.');
-						}
+	const exists = await fileExists(packageJsonPath);
+	if (exists) {
+		const file = await readFile(packageJsonPath, 'utf8');
+		const packageJson = JSON.parse(file);
+		if (!validDescription(packageJson.description)) {
+			result.push('A description property is required. It must be a string which describes the component.');
+		}
+		if (!validKeywords(packageJson.keywords)) {
+			result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
+		}
+		if (!validName(packageJson.name)) {
+			result.push('The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.');
+		}
 
-						if (result.length > 0) {
-							const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management';
-							if (isCI) {
-								const newLine = "%0A";
-								console.log(`::error file=package.json,line=1,col=1::${message.replace(/\n/g, newLine)}`);
-							}
-							const e = new Error(message);
-							e.stack = '';
-							throw e;
-						} else {
-							return result;
-						}
-					});
+		const invalidExplanation = validJavaScriptEntryPoint(packageJson, config.cwd);
+		if (invalidExplanation) {
+			result.push(invalidExplanation);
+		}
+
+		if (result.length > 0) {
+			const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management';
+			if (isCI) {
+				const newLine = "%0A";
+				console.log(`::error file=package.json,line=1,col=1::${message.replace(/\n/g, newLine)}`);
 			}
-		});
+			const e = new Error(message);
+			e.stack = '';
+			throw e;
+		} else {
+			return result;
+		}
+	}
 }
 
 module.exports = cfg => {

--- a/test/integration/demo/fixtures/multiple-demos/package.json
+++ b/test/integration/demo/fixtures/multiple-demos/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@financial-times/o-multiple-demos",
   "description": "a fixture to test the demo command of origami-build-tools",
-  "main": "main.js"
+  "browser": "main.js"
 }

--- a/test/integration/verify/fixtures/js-custom-eslint/package.json
+++ b/test/integration/verify/fixtures/js-custom-eslint/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/js-custom-eslint",
   "version": "1.0.0",
   "description": "for a fixture",
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/js-es5/package.json
+++ b/test/integration/verify/fixtures/js-es5/package.json
@@ -2,8 +2,6 @@
 	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
-	"main": [
-		"main.js"
-	],
+	"browser": "main.js",
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/js-es6/package.json
+++ b/test/integration/verify/fixtures/js-es6/package.json
@@ -2,8 +2,6 @@
 	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
-	"main": [
-		"main.js"
-	],
+	"browser": "main.js",
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/js-es7/package.json
+++ b/test/integration/verify/fixtures/js-es7/package.json
@@ -2,8 +2,6 @@
 	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
-	"main": [
-		"main.js"
-	],
+	"browser": "main.js",
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/js-invalid/package.json
+++ b/test/integration/verify/fixtures/js-invalid/package.json
@@ -3,7 +3,7 @@
   "description": "for a fixture",
   "keywords": [],
   "version": "1.0.0",
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/js-npm-dependency/package.json
+++ b/test/integration/verify/fixtures/js-npm-dependency/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/test-component",
   "description": "for a fixture",
   "keywords": [],
-  "main": "main.js",
+  "browser": "main.js",
   "type": "module",
   "dependencies": {
     "o-test-component": "1.0.26"

--- a/test/integration/verify/fixtures/no-js-or-sass/package.json
+++ b/test/integration/verify/fixtures/no-js-or-sass/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/no-readme/package.json
+++ b/test/integration/verify/fixtures/no-readme/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
@@ -2,6 +2,6 @@
 	"name": "@financial-times/test-component",
 	"description": "for a fixture",
 	"keywords": [],
-	"main": [],
+	"browser": "main.js",
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/readme-invalid-name/package.json
+++ b/test/integration/verify/fixtures/readme-invalid-name/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/readme-invalid/package.json
+++ b/test/integration/verify/fixtures/readme-invalid/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/readme-valid-lowercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-lowercase/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/readme-valid-uppercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-uppercase/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/sass-custom-config/package.json
+++ b/test/integration/verify/fixtures/sass-custom-config/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/integration/verify/fixtures/sass-invalid/package.json
+++ b/test/integration/verify/fixtures/sass-invalid/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "for a fixture",
   "keywords": [],
-  "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/unit/fixtures/o-test/package.json
+++ b/test/unit/fixtures/o-test/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "for a fixture",
 	"keywords": [],
-  "main": "main.js",
+  "browser": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The component v2 specification states that if a main.js file exists, then the `browser` field must be set to `"main.js"`. This commit updates the verify task to ensure that the component being tested adheres to these rules.

I've quoted below the parts of the specification this is testing.

>  - It **must** include a <a href="https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser">`browser`</a> property set to the component's main JavaScript file (`main.js`) **_if_** it exists.

Those came from the spec v2 pull-request -- https://github.com/Financial-Times/origami-website/pull/273/files#diff-5ebc2f3b798414ec905f3fdceb910557607b8d779a56bf1ce09ad48e32fd085aR88

I've also added in a check for the opposite situation, if no `main.js` file exists, then the `browser` field should not exist. This is not currently written in the specification though. If we don't want this functionality, I will remove it. If we do want this functionality, I will update the specification to reflect this.