### PR TITLE
Make verify-origami-json look for all the different origamiType variations

### DIFF
--- a/lib/tasks/verify-origami-json.js
+++ b/lib/tasks/verify-origami-json.js
@@ -9,6 +9,37 @@ const isCI = require('is-ci');
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
 
+// https://origami.ft.com/spec/v1/manifest/#origamitype
+// "component" or "module": A front-end component that follows the component specification
+// "imageset": A set of images that have an alias on the Origami Image Service
+// "service": An HTTP service that follows the service specification
+// "cli": A command line tool
+// "library": A library that is not a front-end component
+// "website": Origami websites that aren’t intended to be services
+// "config": Projects that are configuration for other projects
+// "example": Example and boilerplate projects
+// "meta": Repository-only projects that relate to how Origami works
+// null: An Origami project that does not fit any of the named categories
+function isValidOrigamiType(origamiType) {
+	switch (origamiType) {
+		case "component":
+		case "module":
+		case "imageset":
+		case "service":
+		case "cli":
+		case "library":
+		case "website":
+		case "config":
+		case "example":
+		case "meta":
+		case null: {
+			return true;
+		}
+		default:
+			return false;
+	}
+}
+
 function origamiJson(config) {
 	const result = [];
 
@@ -20,8 +51,9 @@ function origamiJson(config) {
 					.then(file => {
 						const origamiJson = JSON.parse(file);
 						const componentDemos = origamiJson.demos;
-						if (origamiJson.origamiType !== 'imageset' && origamiJson.origamiType !== 'module' && origamiJson.origamiType !== 'service') {
-							result.push('The origamiType property needs to be set to either "imageset", "module" or "service"');
+
+						if (!isValidOrigamiType(origamiJson.origamiType)) {
+							result.push('The origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null');
 						}
 						if (typeof origamiJson.origamiVersion === 'number') {
 							result.push('The origamiVersion property must be a string.');

--- a/test/unit/tasks/verify-origami-json.test.js
+++ b/test/unit/tasks/verify-origami-json.test.js
@@ -102,7 +102,7 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'The origamiType property needs to be set to either "imageset", "module" or "service"\n' +
+						'The origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null\n' +
 						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.\n' +
 						'The support property must be an email or url to an issue tracker for this module\n' +
 						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
@@ -120,7 +120,7 @@ describe('verify-origami-json', function () {
 				proclaim.calledOnce(console.log);
 				proclaim.calledWithExactly(
 					console.log,
-					`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+					`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 				);
 			}
 		});
@@ -180,7 +180,7 @@ describe('verify-origami-json', function () {
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0A'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.'%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.'%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});
@@ -195,13 +195,13 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'The origamiType property needs to be set to either "imageset", "module" or "service"\n\n' +
+						'The origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null\n\n' +
 						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});
@@ -216,13 +216,13 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'The origamiType property needs to be set to either "imageset", "module" or "service"\n\n' +
+						'The origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null\n\n' +
 						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});
@@ -382,7 +382,7 @@ describe('verify-origami-json', function () {
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "imageset", "module" or "service"%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "module", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this module%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
 					);
 				});
 		});


### PR DESCRIPTION
When migrating ftdomdelegate we found that `obt verify` reports a failure because ftdomdelegate is listed as a library.

![image](https://user-images.githubusercontent.com/1569131/114433799-26140280-9bba-11eb-938d-d769b39275db.png)

The three options I can think of to resolve this are:
1.  Make obt check for all the possible allowed values of origamiType
2.  Remove origamiType from the specification
3.  Remove obt from the projects which are not components, such as ftdomdelegate
