### PR TITLE
Only check packages are in the @financial-times scope if they are origami components

### DIFF
--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -88,20 +88,33 @@ function isValidNpmName(name) {
 	return validateNpmPackageName(name).validForNewPackages;
 }
 
+async function isOrigamiComponent(workingDirectory) {
+	const origamiJsonPath = path.join(workingDirectory, '/origami.json');
+	const origamiJsonExists = await fileExists(origamiJsonPath);
+	if (origamiJsonExists) {
+		const origamiJson = JSON.parse(await readFile(origamiJsonPath, 'utf8'));
+		if (origamiJson.origamiType === 'component' || origamiJson.origamiType === 'module') {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 async function packageJson(config) {
 	const result = [];
 	const packageJsonPath = path.join(config.cwd, '/package.json');
-	const exists = await fileExists(packageJsonPath);
-	if (exists) {
-		const file = await readFile(packageJsonPath, 'utf8');
-		const packageJson = JSON.parse(file);
+	const packageJsonExists = await fileExists(packageJsonPath);
+
+	if (packageJsonExists) {
+		const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
 		if (!validDescription(packageJson.description)) {
 			result.push('A description property is required. It must be a string which describes the component.');
 		}
 		if (!validKeywords(packageJson.keywords)) {
 			result.push('The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.');
 		}
-		if (!validName(packageJson.name)) {
+		if (!validName(packageJson.name) && await isOrigamiComponent(config.cwd)) {
 			result.push('The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.');
 		}
 

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -19,7 +19,7 @@ const oTestPath = 'test/unit/fixtures/o-test';
 const pathSuffix = '-verify';
 const verifyTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
 
-describe.only('verify-package-json', function () {
+describe('verify-package-json', function () {
 	let verifyPackageJson;
 	const originalConsole = global.console;
 	let console;


### PR DESCRIPTION
ftdomdelegate is an example of a library we maintain which uses obt to run it's tests. It is not an origami component nor is it under the @financial-times npm scope

The definition of origami component I'm using for this pull-request is `origami.json.origamiType` set to either `"module"` or `"component"`

Here is a list of the projects which are origami libraries and listed in the origami registry:
- ft-date-format
- get-github-public-organisation-repositories
- karma-proclaim
- node-health-check
- origami-navigation-data
- origami-repo-data-client-node
- origami-service
- polyfill-library
- sass
- streamcat
- svg-tint-stream

After looking through how all those projects are set up, none of them use obt, which makes me think we should not use obt for ftdomdelegate either

Should ftdomdelegate and the other origami libraries use origami-build-tools?