### PR TITLE
Enforce that a package.json file exists for origami components instead of skipping the validation

### DIFF
--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -113,19 +113,21 @@ async function packageJson(config) {
 		if (invalidExplanation) {
 			result.push(invalidExplanation);
 		}
+	} else {
+		result.push(`No package.json file found. To make this an origami component, create a package.json file following the format defined at: https://origami.ft.com/spec/v2/components/#package-management`);
+	}
 
-		if (result.length > 0) {
-			const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management';
-			if (isCI) {
-				const newLine = "%0A";
-				console.log(`::error file=package.json,line=1,col=1::${message.replace(/\n/g, newLine)}`);
-			}
-			const e = new Error(message);
-			e.stack = '';
-			throw e;
-		} else {
-			return result;
+	if (result.length > 0) {
+		const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management';
+		if (isCI) {
+			const newLine = "%0A";
+			console.log(`::error file=package.json,line=1,col=1::${message.replace(/\n/g, newLine)}`);
 		}
+		const e = new Error(message);
+		e.stack = '';
+		throw e;
+	} else {
+		return result;
 	}
 }
 
@@ -135,16 +137,6 @@ module.exports = cfg => {
 
 	return {
 		title: 'Verifying your package.json',
-		task: () => packageJson(config),
-		skip: function () {
-			const packageJsonPath = path.join(config.cwd, '/package.json');
-
-			return fileExists(packageJsonPath)
-				.then(exists => {
-					if (!exists) {
-						return `No package.json file found. To make this an origami component, create a file at ${path.join(config.cwd, '/package.json')} following the format defined at: https://origami.ft.com/spec/v2/components/#package-management`;
-					}
-				});
-		}
+		task: () => packageJson(config)
 	};
 };

--- a/test/unit/tasks/demo-build.test.js
+++ b/test/unit/tasks/demo-build.test.js
@@ -13,10 +13,13 @@ const oNoManifestPath = path.resolve(obtPath, 'test/unit/fixtures/o-no-manifest'
 const pathSuffix = '-demo';
 const demoTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
 const demo = require('../../../lib/tasks/demo-build');
+const denodeify = require('util').promisify;
+const rimraf = denodeify(require('rimraf'));
 
 describe('Demo task', function () {
 
-	beforeEach(function () {
+	beforeEach(async function () {
+		await rimraf(demoTestPath);
 		fs.copySync(path.resolve(obtPath, oTestPath), demoTestPath);
 		process.chdir(demoTestPath);
 		mockery.enable({
@@ -26,9 +29,9 @@ describe('Demo task', function () {
 		});
 	});
 
-	afterEach(function () {
+	afterEach(async function () {
 		process.chdir(obtPath);
-		fs.removeSync(demoTestPath);
+		await rimraf(demoTestPath);
 		sinon.restore();
 		mockery.resetCache();
 		mockery.deregisterAll();


### PR DESCRIPTION
Currently obt will skip the package.json validation steps if no package.json exists.
As the specification states the file must exist, we should have obt fails validation if the file does not exist.

The below is from the 2.0 draft specification:
>Origami components **must** include the following files:
>
>  - `main.js` **_if_** the component has JavaScript functionality
>  - `main.scss` **_if_** the component has styles
>  - `origami.json` as outlined in [Origami.json manifest](#origamijson-manifest) above
>  - `package.json` as to ensure the component is installable via the <a href="https://npmjs.com/" class="o-typography-link--external">npm package manager</a>