### PR TITLE
Verify supported npm version is set to a minimum of 7.0.0

### DIFF
--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -6,6 +6,7 @@ const path = require('path');
 const denodeify = require('util').promisify;
 const isCI = require('is-ci');
 const validateNpmPackageName = require('validate-npm-package-name');
+const semver = require('semver');
 
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
@@ -37,6 +38,27 @@ function validKeywords(keywords) {
 	} else {
 		return false;
 	}
+}
+
+/**
+ * Checks whether engines conforms to the origami package.json specification.
+ * @param {Object} engines The engines object
+ * @returns {Boolean} Whether `engines` conforms to the origami package.json specification.
+ */
+function validEngines(engines) {
+	if (engines && engines.npm) {
+		try {
+			const validSemver = semver.validRange(engines.npm);
+			if (validSemver) {
+				// origami 2.0 only supports npm 7 or newer
+				const minSupportedNpm = semver.minVersion(engines.npm);
+				return semver.satisfies(minSupportedNpm, '^7');
+			}
+		} catch (error) {
+			return false;
+		}
+	}
+	return false;
 }
 
 /**
@@ -107,6 +129,9 @@ async function packageJson(config) {
 		}
 		if (!validName(packageJson.name)) {
 			result.push('The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.');
+		}
+		if (!validEngines(packageJson.engines)) {
+			result.push('The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.');
 		}
 
 		const invalidExplanation = validJavaScriptEntryPoint(packageJson, config.cwd);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -56,6 +56,7 @@
 				"root-check": "^1.0.0",
 				"sass": "^1.26.10",
 				"sass-true": "^6.0.0",
+				"semver": "^6.3.0",
 				"serve-handler": "^6.1.2",
 				"sinon": "^9.0.2",
 				"snyk": "^1.425.4",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"root-check": "^1.0.0",
 		"sass": "^1.26.10",
 		"sass-true": "^6.0.0",
+		"semver": "^6.3.0",
 		"serve-handler": "^6.1.2",
 		"sinon": "^9.0.2",
 		"snyk": "^1.425.4",

--- a/test/integration/install/fixtures/non-existent-npm-dependency/package.json
+++ b/test/integration/install/fixtures/non-existent-npm-dependency/package.json
@@ -1,6 +1,7 @@
 {
 	"type": "module",
+	"engines": {"npm": "^7"},
 	"dependencies": {
-    "asdfghjklpoinmutrdbtt": "^0.1.0"
+		"asdfghjklpoinmutrdbtt": "^0.1.0"
 	}
 }

--- a/test/integration/install/fixtures/with-npm-dependencies/package-lock.json
+++ b/test/integration/install/fixtures/with-npm-dependencies/package-lock.json
@@ -7,6 +7,9 @@
 			"name": "@financial-times/with-npm-dependencies",
 			"dependencies": {
 				"lodash": "*"
+			},
+			"engines": {
+				"npm": "^7"
 			}
 		},
 		"node_modules/lodash": {

--- a/test/integration/install/fixtures/with-npm-dependencies/package.json
+++ b/test/integration/install/fixtures/with-npm-dependencies/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "@financial-times/with-npm-dependencies",
 	"type": "module",
+	"engines": {
+		"npm": "^7"
+	},
 	"dependencies": {
 		"lodash": "*"
 	}

--- a/test/integration/test/fixtures/with-npm-dependency-installed/package-lock.json
+++ b/test/integration/test/fixtures/with-npm-dependency-installed/package-lock.json
@@ -7,6 +7,9 @@
             "name": "@financial-times/test-component",
             "dependencies": {
                 "o-test-component": "Financial-Times/o-test-component#v1.0.33"
+            },
+            "engines": {
+                "npm": "^7"
             }
         },
         "node_modules/o-test-component": {

--- a/test/integration/test/fixtures/with-npm-dependency-installed/package.json
+++ b/test/integration/test/fixtures/with-npm-dependency-installed/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@financial-times/test-component",
     "type": "module",
+    "engines": {
+        "npm": "^7"
+    },
     "dependencies": {
         "o-test-component": "Financial-Times/o-test-component#v1.0.33"
     }

--- a/test/integration/verify/fixtures/js-custom-eslint/package.json
+++ b/test/integration/verify/fixtures/js-custom-eslint/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "eslint-config-origami-component": "^1.1.1"
   }

--- a/test/integration/verify/fixtures/js-es5/package.json
+++ b/test/integration/verify/fixtures/js-es5/package.json
@@ -3,5 +3,8 @@
 	"description": "for a fixture",
 	"keywords": [],
 	"browser": "main.js",
+	"engines": {
+		"npm": "^7"
+	},
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/js-es6/package.json
+++ b/test/integration/verify/fixtures/js-es6/package.json
@@ -3,5 +3,8 @@
 	"description": "for a fixture",
 	"keywords": [],
 	"browser": "main.js",
+	"engines": {
+		"npm": "^7"
+	},
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/js-es7/package.json
+++ b/test/integration/verify/fixtures/js-es7/package.json
@@ -3,5 +3,8 @@
 	"description": "for a fixture",
 	"keywords": [],
 	"browser": "main.js",
+	"engines": {
+		"npm": "^7"
+	},
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/js-invalid/package.json
+++ b/test/integration/verify/fixtures/js-invalid/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "eslint-config-origami-component": "^1.1.1"
   }

--- a/test/integration/verify/fixtures/js-npm-dependency/package.json
+++ b/test/integration/verify/fixtures/js-npm-dependency/package.json
@@ -4,6 +4,9 @@
   "keywords": [],
   "browser": "main.js",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "dependencies": {
     "o-test-component": "1.0.26"
   }

--- a/test/integration/verify/fixtures/no-js-or-sass/package.json
+++ b/test/integration/verify/fixtures/no-js-or-sass/package.json
@@ -9,6 +9,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "remark-preset-lint-origami-component": "2.0.0-beta.1",
     "stylelint": "^13.7.0",

--- a/test/integration/verify/fixtures/no-readme/package.json
+++ b/test/integration/verify/fixtures/no-readme/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "remark-preset-lint-origami-component": "2.0.0-beta.1"
   }

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/package.json
@@ -3,5 +3,8 @@
 	"description": "for a fixture",
 	"keywords": [],
 	"browser": "main.js",
+	"engines": {
+		"npm": "^7"
+	},
 	"type": "module"
 }

--- a/test/integration/verify/fixtures/readme-invalid-name/package.json
+++ b/test/integration/verify/fixtures/readme-invalid-name/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "remark-preset-lint-origami-component": "2.0.0-beta.1"
   }

--- a/test/integration/verify/fixtures/readme-invalid/package.json
+++ b/test/integration/verify/fixtures/readme-invalid/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "eslint-config-origami-component": "^1.1.1",
     "remark-preset-lint-origami-component": "2.0.0-beta.1",

--- a/test/integration/verify/fixtures/readme-valid-lowercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-lowercase/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "remark-preset-lint-origami-component": "2.0.0-beta.1"
   }

--- a/test/integration/verify/fixtures/readme-valid-uppercase/package.json
+++ b/test/integration/verify/fixtures/readme-valid-uppercase/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "remark-preset-lint-origami-component": "2.0.0-beta.1"
   }

--- a/test/integration/verify/fixtures/sass-custom-config/package.json
+++ b/test/integration/verify/fixtures/sass-custom-config/package.json
@@ -9,6 +9,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "devDependencies": {
     "remark-preset-lint-origami-component": "2.0.0-beta.1",
     "stylelint": "^13.7.0",

--- a/test/integration/verify/fixtures/sass-npm-dependency/package.json
+++ b/test/integration/verify/fixtures/sass-npm-dependency/package.json
@@ -3,6 +3,9 @@
   "description": "for a fixture",
   "keywords": [],
   "type": "module",
+  "engines": {
+    "npm": "^7"
+  },
   "dependencies": {
     "o-test-component": "1.0.7"
   }

--- a/test/integration/verify/fixtures/sass/package.json
+++ b/test/integration/verify/fixtures/sass/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "@financial-times/test-component",
 	"description": "for a fixture",
+	"engines": {
+		"npm": "^7"
+	},
 	"keywords": [],
 	"type": "module"
 }

--- a/test/unit/fixtures/o-test/package.json
+++ b/test/unit/fixtures/o-test/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@financial-times/o-test",
-  "type": "module",
-  "version": "1.0.0",
-  "description": "for a fixture",
+	"name": "@financial-times/o-test",
+	"type": "module",
+	"engines": {
+		"npm": "^7"
+	},
+	"version": "1.0.0",
+	"description": "for a fixture",
 	"keywords": [],
-  "browser": "main.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
-  "license": "ISC"
+	"browser": "main.js",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"author": "",
+	"license": "ISC"
 }

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -116,6 +116,7 @@ describe('verify-package-json', function () {
 						'A description property is required. It must be a string which describes the component.\n' +
 						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n' +
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n' +
+						'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n' +
 						'Because the file `main.js` exists, the `browser` property is required. It must have the value `"main.js"`.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
@@ -123,7 +124,7 @@ describe('verify-package-json', function () {
 
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -148,13 +149,14 @@ describe('verify-package-json', function () {
 						'A description property is required. It must be a string which describes the component.\n' +
 						'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n' +
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n' +
+						'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n' +
 						'Because the file `main.js` exists, the `browser` property is required. It must have the value `"main.js"`.\n\n' +
 						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 				);
 			}
 
@@ -642,6 +644,137 @@ describe('verify-package-json', function () {
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
 							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						);
+					}
+
+					if (!errored) {
+						proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+					}
+				});
+			});
+
+		});
+
+		context('the engines property', function(){
+			context('when engines exists', function() {
+				it('should fail if missing the npm property', async function () {
+					const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+					packageJSON.engines = "carrot";
+					fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+					let errored;
+					try {
+						await verifyPackageJson().task();
+						errored = false;
+					} catch (error) {
+						errored = true;
+						proclaim.equal(
+							error.message,
+							'Failed linting:\n\n' +
+							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
+							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						);
+						proclaim.calledOnce(console.log);
+						proclaim.deepStrictEqual(
+							console.log.lastCall.args,
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						);
+					}
+
+					if (!errored) {
+						proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+					}
+				});
+				it('should fail if npm property is set to SemVer ranges which allows npm versions below 7', async function () {
+					const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+					packageJSON.engines = {npm: '>=6'};
+					fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+					let errored;
+					try {
+						await verifyPackageJson().task();
+						errored = false;
+					} catch (error) {
+						errored = true;
+						proclaim.equal(
+							error.message,
+							'Failed linting:\n\n' +
+							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
+							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						);
+						proclaim.calledOnce(console.log);
+						proclaim.deepStrictEqual(
+							console.log.lastCall.args,
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						);
+					}
+
+					if (!errored) {
+						proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+					}
+				});
+
+				it('should fail if npm property is not a valid SemVer range', async function () {
+					const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+					packageJSON.engines = {npm: 'penguin'};
+					fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+					let errored;
+					try {
+						await verifyPackageJson().task();
+						errored = false;
+					} catch (error) {
+						errored = true;
+						proclaim.equal(
+							error.message,
+							'Failed linting:\n\n' +
+							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
+							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						);
+						proclaim.calledOnce(console.log);
+						proclaim.deepStrictEqual(
+							console.log.lastCall.args,
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						);
+					}
+
+					if (!errored) {
+						proclaim.fail('verifyPackageJson().task() did not return a rejected promise', 'verifyPackageJson().task() should have returned a rejected promise');
+					}
+				});
+
+				it('should pass if npm property is set to SemVer ranges which disallows npm versions below 7', async function () {
+					const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+					packageJSON.engines = {'npm': '>=7'};
+					fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+					await verifyPackageJson().task();
+					proclaim.notCalled(console.log);
+				});
+			});
+
+			context('when engines does not exist', function() {
+				it('should fail', async function () {
+					const packageJSON = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+					delete packageJSON.engines;
+					fs.writeFileSync('package.json', JSON.stringify(packageJSON), 'utf8');
+
+					let errored;
+					try {
+						await verifyPackageJson().task();
+						errored = false;
+					} catch (error) {
+						errored = true;
+						proclaim.equal(
+							error.message,
+							'Failed linting:\n\n' +
+							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
+							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						);
+						proclaim.calledOnce(console.log);
+						proclaim.deepStrictEqual(
+							console.log.lastCall.args,
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
 						);
 					}
 


### PR DESCRIPTION
This verification helps ensure origami components adhere to the specification

The origami 2.0 spec states:
>It *must* include an engines property set to an object which has an npm property set to a SemVer range which disallows anything below v7.0.0. E.G. ^7 would be valid as would >= 7.