### PR TITLE
Remove "origamiCategory", it is no longer part of spec v2 components.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3307,9 +3307,9 @@
 			}
 		},
 		"create-origami-component": {
-			"version": "1.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/create-origami-component/-/create-origami-component-1.0.0-beta.2.tgz",
-			"integrity": "sha512-rRI5bNuVZoc8nxvdcqxDAUbLQGLVTT5Q2qZX18SQpDsPQO7HJwGGNezY1N6Y2aCdHaY94lPBSr9ReBu4W8X4EQ==",
+			"version": "1.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/create-origami-component/-/create-origami-component-1.0.0-beta.3.tgz",
+			"integrity": "sha512-WoE6rK0ITv0a1DWw1/1yPokfJLy877T5UnMt0f7n4ShX9sBx6zk6mmHZgQpKjGR2KaoNrO+INbjZ6HImtP5ZbQ==",
 			"requires": {
 				"chalk": "^4.0.0",
 				"cli-ux": "^5.4.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"chalk": "^4.1.1",
 		"chokidar": "^3.5.1",
 		"colors": "^1.4.0",
-		"create-origami-component": "^1.0.0-beta.2",
+		"create-origami-component": "^1.0.0-beta.3",
 		"deglob": "^4.0.1",
 		"esbuild": "^0.11.13",
 		"eslint": "^7.24.0",

--- a/test/integration/demo/fixtures/multiple-demos/origami.json
+++ b/test/integration/demo/fixtures/multiple-demos/origami.json
@@ -2,7 +2,6 @@
 	"description": "a fixture to test the demo command of origami-build-tools",
 	"keywords": [],
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": ["master"],
 	"support": "https://github.com/Financial-Times/o-multiple-demos/issues",

--- a/test/integration/install/fixtures/no-npm-dependencies/origami.json
+++ b/test/integration/install/fixtures/no-npm-dependencies/origami.json
@@ -2,7 +2,6 @@
     "description": "fixture, no-dependencies",
     "keywords": [],
     "origamiType": "component",
-    "origamiCategory": "components",
     "origamiVersion": "2.0",
     "brands": [],
     "support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/install/fixtures/non-existent-npm-dependency/origami.json
+++ b/test/integration/install/fixtures/non-existent-npm-dependency/origami.json
@@ -2,7 +2,6 @@
     "description": "fixture, non-existent-npm-dependency",
     "keywords": [],
     "origamiType": "component",
-    "origamiCategory": "components",
     "origamiVersion": "2.0",
     "brands": [],
     "support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/install/fixtures/with-npm-dependencies/origami.json
+++ b/test/integration/install/fixtures/with-npm-dependencies/origami.json
@@ -2,7 +2,6 @@
     "description": "fixture, with-npm-dependencies",
     "keywords": [],
     "origamiType": "component",
-    "origamiCategory": "components",
     "origamiVersion": "2.0",
     "brands": [],
     "support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/test/fixtures/with-npm-dependency-installed/origami.json
+++ b/test/integration/test/fixtures/with-npm-dependency-installed/origami.json
@@ -2,7 +2,6 @@
     "description": "fixture, with-npm-dependency-installed",
     "keywords": [],
     "origamiType": "component",
-    "origamiCategory": "components",
     "origamiVersion": "2.0",
     "brands": [],
     "support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/js-custom-eslint/origami.json
+++ b/test/integration/verify/fixtures/js-custom-eslint/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/js-es5/origami.json
+++ b/test/integration/verify/fixtures/js-es5/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/js-es6/origami.json
+++ b/test/integration/verify/fixtures/js-es6/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/js-es7/origami.json
+++ b/test/integration/verify/fixtures/js-es7/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/js-invalid/origami.json
+++ b/test/integration/verify/fixtures/js-invalid/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/js-npm-dependency/origami.json
+++ b/test/integration/verify/fixtures/js-npm-dependency/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/no-js-or-sass/origami.json
+++ b/test/integration/verify/fixtures/no-js-or-sass/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/no-readme/origami.json
+++ b/test/integration/verify/fixtures/no-readme/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/readme-custom-remarkrc/origami.json
+++ b/test/integration/verify/fixtures/readme-custom-remarkrc/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/readme-invalid-name/origami.json
+++ b/test/integration/verify/fixtures/readme-invalid-name/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/readme-invalid/origami.json
+++ b/test/integration/verify/fixtures/readme-invalid/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/readme-valid-lowercase/origami.json
+++ b/test/integration/verify/fixtures/readme-valid-lowercase/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/readme-valid-uppercase/origami.json
+++ b/test/integration/verify/fixtures/readme-valid-uppercase/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/sass-custom-config/origami.json
+++ b/test/integration/verify/fixtures/sass-custom-config/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/sass-invalid/origami.json
+++ b/test/integration/verify/fixtures/sass-invalid/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/sass-npm-dependency/origami.json
+++ b/test/integration/verify/fixtures/sass-npm-dependency/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",

--- a/test/integration/verify/fixtures/sass/origami.json
+++ b/test/integration/verify/fixtures/sass/origami.json
@@ -1,6 +1,5 @@
 {
 	"origamiType": "component",
-	"origamiCategory": "components",
 	"origamiVersion": "2.0",
 	"brands": [],
 	"support": "https://github.com/Financial-Times/o-example/issues",


### PR DESCRIPTION
https://github.com/Financial-Times/origami/pull/120