### PR TITLE
Update integration test temporary path. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ node_modules
 npm-debug.log*
 .DS_Store
 .editorconfig
-test/integration/demo/fixtures/no-demos/o-component-boilerplate/
+test/integration/tmp/
 ws-*

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -83,8 +83,7 @@
 				"nixt": "^0.5.1",
 				"node-version": "^2.0.0",
 				"npm-prepublish": "^1.2.3",
-				"rimraf": "^3.0.2",
-				"unique-temp-dir": "^1.0.0"
+				"rimraf": "^3.0.2"
 			},
 			"engines": {
 				"node": ">= 14.16.1",
@@ -17220,12 +17219,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-			"dev": true
-		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -17362,20 +17355,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/unique-temp-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
-			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-			"dev": true,
-			"dependencies": {
-				"mkdirp": "^0.5.1",
-				"os-tmpdir": "^1.0.1",
-				"uid2": "0.0.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/unist-util-find": {
@@ -31505,12 +31484,6 @@
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
 			"integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
 		},
-		"uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-			"dev": true
-		},
 		"unbox-primitive": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -31599,17 +31572,6 @@
 			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
 			"requires": {
 				"crypto-random-string": "^2.0.0"
-			}
-		},
-		"unique-temp-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
-			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-			"dev": true,
-			"requires": {
-				"mkdirp": "^0.5.1",
-				"os-tmpdir": "^1.0.1",
-				"uid2": "0.0.3"
 			}
 		},
 		"unist-util-find": {

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
 		"nixt": "^0.5.1",
 		"node-version": "^2.0.0",
 		"npm-prepublish": "^1.2.3",
-		"rimraf": "^3.0.2",
-		"unique-temp-dir": "^1.0.0"
+		"rimraf": "^3.0.2"
 	},
 	"repository": {
 		"type": "git",

--- a/test/integration/demo/demo.test.js
+++ b/test/integration/demo/demo.test.js
@@ -7,7 +7,7 @@ const process = require('process');
 const obtBinPath = require('../helpers/obtpath');
 const proclaim = require('proclaim');
 const fileExists = require('../helpers/fileExists');
-const uniqueTempDir = require('unique-temp-dir');
+const tmpdir = require('../helpers/tmpdir');
 const fs = require('fs-extra');
 const rimraf = require("../helpers/delete");
 
@@ -43,12 +43,14 @@ describe('obt demo', function () {
 
 
 	describe('component with multiple demos with the same name', function () {
-		const testDirectory = uniqueTempDir({ create: true });
-		const fixturesDirectory = path.resolve(__dirname, 'fixtures/multiple-demos');
+		let testDirectory;
+		let fixturesDirectory;
 
-		before(function () {
+		before(async function () {
 			// copy fixture (example component with multiple demos)
 			// to a temporary test directory
+			testDirectory = await tmpdir('obt-demo-task-');
+			fixturesDirectory = path.resolve(__dirname, 'fixtures/multiple-demos');
 			fs.copySync(fixturesDirectory, testDirectory);
 			process.chdir(testDirectory);
 			// update the demo configuration in origami.json so multiple demos
@@ -88,16 +90,20 @@ describe('obt demo', function () {
 	});
 
 	describe('component with multiple valid demos', function () {
-		const testDirectory = uniqueTempDir({ create: true });
-		const fixturesDirectory = path.resolve(__dirname, 'fixtures/multiple-demos');
-		const expectedBuiltDemoPath1 = path.resolve(testDirectory, 'demos/local/demo-1.html');
-		const expectedBuiltDemoPath2 = path.resolve(testDirectory, 'demos/local/demo-2.html');
+		let testDirectory;
+		let fixturesDirectory;
+		let expectedBuiltDemoPath1;
+		let expectedBuiltDemoPath2;
 		let builtDemoHtml1 = '';
 		let builtDemoHtml2 = '';
 
-		before(function () {
+		before(async function () {
 			// copy fixture (example component with multiple demos)
 			// to a temporary test directory
+			testDirectory = await tmpdir('obt-demo-task-');
+			fixturesDirectory = path.resolve(__dirname, 'fixtures/multiple-demos');
+			expectedBuiltDemoPath1 = path.resolve(testDirectory, 'demos/local/demo-1.html');
+			expectedBuiltDemoPath2 = path.resolve(testDirectory, 'demos/local/demo-2.html');
 			fs.copySync(fixturesDirectory, testDirectory);
 			process.chdir(testDirectory);
 			return obtBinPath()

--- a/test/integration/helpers/tmpdir.js
+++ b/test/integration/helpers/tmpdir.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const fileExists = require('./fileExists');
+const path = require('path');
+const { mkdir, mkdtemp } = require('fs/promises');
+
+/**
+ * Return a path to a unique temporary directory to run integration tests in.
+ * Previously `os.tmpdir` was used, but caused problems in Github actions where
+ * the temporary directory did not exist.
+ *
+ * @param {String} prefix [''] - A prefix for the unique temporary directory created.
+ * @returns {String} The path to a temporary directory for running integration tests.
+ */
+module.exports = async function tmpdir(prefix = '') {
+	const rootTemporaryDirectory = path.join(__dirname, '../tmp');
+	const exists = await fileExists(rootTemporaryDirectory);
+	if (!exists) {
+		await mkdir(rootTemporaryDirectory);
+	}
+	const uniqueTemporaryDirectory = await mkdtemp(path.join(rootTemporaryDirectory, prefix));
+	return uniqueTemporaryDirectory;
+};

--- a/test/integration/init/init.test.js
+++ b/test/integration/init/init.test.js
@@ -7,7 +7,7 @@ const rimraf = require("../helpers/delete");
 const nixt = require("nixt");
 const tmpdir = require('../helpers/tmpdir');
 
-describe("obt boilerplate", function () {
+describe("obt init", function () {
 	this.timeout(10 * 1000);
 
 	describe("initialising a new component", function () {

--- a/test/integration/init/init.test.js
+++ b/test/integration/init/init.test.js
@@ -5,7 +5,7 @@ const process = require("process");
 const obtBinPath = require("../helpers/obtpath");
 const rimraf = require("../helpers/delete");
 const nixt = require("nixt");
-const uniqueTempDir = require('unique-temp-dir');
+const tmpdir = require('../helpers/tmpdir');
 
 describe("obt boilerplate", function () {
 	this.timeout(10 * 1000);
@@ -13,8 +13,8 @@ describe("obt boilerplate", function () {
 	describe("initialising a new component", function () {
 		describe("obt install && demo && build && verify && test", () => {
 			let testDirectory;
-			beforeEach(function () {
-				testDirectory = uniqueTempDir({create:true});
+			beforeEach(async function () {
+				testDirectory = await tmpdir('obt-init-task-');
 				process.chdir(testDirectory);
 			});
 

--- a/test/integration/test/test.test.js
+++ b/test/integration/test/test.test.js
@@ -3,14 +3,10 @@
 'use strict';
 
 const execa = require('execa');
-const path = require('path');
-const os = require('os');
 const process = require('process');
 const rimraf = require('../helpers/delete');
 const obtBinPath = require('../helpers/obtpath');
-const fs = require('fs');
-const { promisify } = require('util');
-const mkdtemp = promisify(fs.mkdtemp);
+const tmpdir = require('../helpers/tmpdir');
 const proclaim = require('proclaim');
 
 describe('obt test', function () {
@@ -21,7 +17,7 @@ describe('obt test', function () {
 
 	beforeEach(async function () {
 		obt = await obtBinPath();
-		testDirectory = await mkdtemp(path.join(os.homedir(), 'obt-test-'));
+		testDirectory = await tmpdir('obt-test-task-');
 		process.chdir(testDirectory);
 	});
 

--- a/test/integration/verify/verify.test.js
+++ b/test/integration/verify/verify.test.js
@@ -9,9 +9,8 @@ const obtBinPath = require('../helpers/obtpath');
 const rimraf = require('../helpers/delete');
 const fs = require('fs');
 const { promisify } = require('util');
-const mkdtemp = promisify(fs.mkdtemp);
 const writeFile = promisify(fs.writeFile);
-const os = require('os');
+const tmpdir = require('../helpers/tmpdir');
 
 describe('obt verify', function () {
 	let obt;
@@ -92,7 +91,7 @@ describe('obt verify', function () {
 
 
 			it('should error', async function () {
-				const folder = await mkdtemp(path.join(os.tmpdir(), 'foo-'));
+				const folder = await tmpdir('obt-verify-task-');
 				const filePath = path.join(folder, 'testFilesystemCaseSensitivity.txt');
 				await writeFile(path.join(folder, 'testFilesystemCaseSensitivity.txt'), "hello", "utf8");
 				const caseSensitiveFileSystem = fs.existsSync(filePath.toUpperCase());

--- a/test/unit/tasks/init.test.js
+++ b/test/unit/tasks/init.test.js
@@ -10,7 +10,7 @@ sinon.assert.expose(proclaim, {
 	prefix: ''
 });
 
-describe('Boilerplate task', function() {
+describe('Init task', function() {
 	let Listr;
 	let init;
 	let buildBoilerplate;


### PR DESCRIPTION
OBT previously had three methods of creating temporary directories
to run tests in. Now each test uses the same helper. Temporary
directories are created within the obt integration test directory
which avoids cluttering our home directory and sidesteps any issues
with the temporary directory `os.tmpdir` we were seeing with Github
Actions.