### PR TITLE
load the demo's dependency javascript before the demo's own javascript to ensure the dependecies are available to be used

### DIFF
--- a/templates/page.mustache
+++ b/templates/page.mustache
@@ -15,13 +15,13 @@
 		<script src="{{{oDemoPolyfillUrl}}}"></script>
 	{{/oDemoPolyfillUrl}}
 
-	{{#oDemoComponentScriptPath}}
-		<script src="{{{ oDemoComponentScriptPath }}}" defer></script>
-	{{/oDemoComponentScriptPath}}
-
 	{{#oDemoDependenciesScriptPath}}
 		<script src="{{{ oDemoDependenciesScriptPath }}}" defer></script>
 	{{/oDemoDependenciesScriptPath}}
+
+	{{#oDemoComponentScriptPath}}
+		<script src="{{{ oDemoComponentScriptPath }}}" defer></script>
+	{{/oDemoComponentScriptPath}}
 
 	{{#oDemoDependenciesStylePath}}
 		<link rel="stylesheet" href="{{{.}}}" />


### PR DESCRIPTION
Previously the demo javascript would load in before the dependencies javascript.

By swapping the order around, the demo javascript can now make use any variables the dependency javascript creates, such as `window.Origami` which contains all the dependencies' JS exports.