### PR TITLE
Remove spec v2 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Creates boilerplate for a new Origami component.
 
 ### `demo` or `d`
 
-Build demos found in the [origami.json manifest](https://origami.ft.com/spec/v1/manifest/#demos).
+Build demos found in the [origami.json manifest](https://origami.ft.com/docs/manifests/origami-json/#demos).
 
 Build a specific demo with the `--demo-filter` option.
 
@@ -98,7 +98,7 @@ Demos consist of HTML, CSS and JS (if Sass & JS exists), and are created in `dem
 
 ### `verify` or `v` or `lint` or `l`
 
-Lints JavaScript, Sass and configuration files against [Origami specification](https://origami.ft.com/spec/v1/components/).
+Lints JavaScript, Sass and configuration files ([see Origami code recommendations](https://origami.ft.com/docs/components/code/)).
 
 ### `test` or `t`
 
@@ -106,7 +106,7 @@ Runs JavaScript and Sass tests.
 
 * If `--debug` is set, the test runner will not exit automatically to allow debugging of the tests.
 
-Checks Sass [includes a primary mixin](https://origami.ft.com/spec/v2/components/sass/#primary-mixin).
+Checks Sass [includes a primary mixin](https://origami.ft.com/docs/components/code/#sass).
 If `pa11y.html` demo exists, confirms it is accessible using [Pa11y](http://pa11y.org/).
 Runs tests using [Karma](https://karma-runner.github.io) defaulting to Chrome Stable, can be configured to use BrowserStack by using the `--browserstack` flag. You will need the environment variables `BROWSER_STACK_USERNAME` and `BROWSER_STACK_ACCESS_KEY` set. This will run the tests on the minimum version for enhanced experience based on the [FT Browser Support Policy[(https://docs.google.com/document/d/1mByh6sT8zI4XRyPKqWVsC2jUfXHZvhshS5SlHErWjXU).
 

--- a/lib/helpers/verify-component-specification-version.js
+++ b/lib/helpers/verify-component-specification-version.js
@@ -14,9 +14,8 @@ module.exports = async () => {
 			'which follow v1 of the Origami component specification. ' +
 			'To work on this component install a previous version of the ' +
 			'Origami Build Tools (v10). Alternatively, upgrade this ' +
-			'component to follow v2 or above of the Origami specification. ' +
-			'See the component specification for more details: ' +
-			'https://origami.ft.com/spec/'
+			'component to follow the latest component recommendations: ' +
+			'https://origami.ft.com/docs/components/code'
 		);
 	}
 	if (!origamiJson || typeof origamiJson.origamiVersion !== 'string') {
@@ -25,8 +24,8 @@ module.exports = async () => {
 			'Origami Build Tools may only be used to develop Origami ' +
 			'components. It looks like this isn\'t an Origami component, ' +
 			'or the component is missing a valid "origami.json". See the ' +
-			'component specification for more details: ' +
-			'https://origami.ft.com/spec/'
+			'origami.json manifest documentation for more details: ' +
+			'https://origami.ft.com/docs/manifests/origami-json/'
 		);
 	}
 };

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -216,7 +216,7 @@ module.exports = async function (cfg) {
 	const demoBuildConfig = [];
 
 	if (demos.length === 0) {
-		const e = new Error('No demos exist in origami.json file. Reference https://origami.ft.com/spec to help configure demos for the component.');
+		const e = new Error('No demos exist in the origami.json file. Reference https://origami.ft.com/docs/manifests/origami-json/ to configure demos in the component\'s origami.json manifest file.');
 		e.stack = '';
 		throw e;
 	}

--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -30,7 +30,7 @@ module.exports = function (cfg) {
 				}
 
 				if (!Array.isArray(demosConfig.demos) || demosConfig.demos.length < 1) {
-					return 'No demos exist in origami.json file. Reference http://origami.ft.com/docs/syntax/origamijson/ to help configure demos for the component.';
+					return 'No demos exist in the origami.json file. Reference https://origami.ft.com/docs/manifests/origami-json/ to configure demos in the component\'s origami.json manifest file.';
 				}
 
 				let demoFilters;

--- a/lib/tasks/test-sass-compilation.js
+++ b/lib/tasks/test-sass-compilation.js
@@ -63,10 +63,10 @@ async function compilationTest(cwd, { silent, brand } = {
 		const missingPrimaryMixin = error.message.includes(primaryMixinErrorCode);
 		const missingPrimaryMixinMessage = 'Origami components require a ' +
 			`primary mixin, in this case "${primaryMixinName}". See the ` +
-			'specification to learn how to add a primary mixin to your ' +
-			'component, or contact the Origami community on Slack in ' +
-			'#origami-support.\n' +
-			'https://origami.ft.com/spec/v2/components/sass/#primary-mixin';
+			'"Create A New Origami Component" tutorial to learn how to add ' +
+			'a primary mixin to your component, or contact the Origami ' +
+			'community on Slack in #origami-support.\n' +
+			'https://origami.ft.com/docs/tutorials/create-a-new-component-part-2/#primary-mixin';
 
 		const errorMessage = missingPrimaryMixin ? missingPrimaryMixinMessage : error.message;
 

--- a/lib/tasks/verify-origami-json.js
+++ b/lib/tasks/verify-origami-json.js
@@ -9,7 +9,7 @@ const isCI = require('is-ci');
 const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
 
-// https://origami.ft.com/spec/v1/manifest/#origamitype
+// https://origami.ft.com/docs/manifests/origami-json/#origamitype
 // "component": A front-end component that follows the component specification
 // "imageset": A set of images that have an alias on the Origami Image Service
 // "service": An HTTP service that follows the service specification
@@ -58,7 +58,7 @@ function origamiJson(config) {
 							result.push('The origamiVersion property must be a string.');
 						}
 						if (typeof origamiJson.origamiVersion !== 'string' || origamiJson.origamiVersion.split('.')[0] !== '2') {
-							result.push('The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.');
+							result.push('The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.');
 						}
 						if (!origamiJson.support) {
 							result.push('The support property must be an email or url to an issue tracker for this project');
@@ -85,7 +85,7 @@ function origamiJson(config) {
 						}
 
 						if (result.length > 0) {
-							const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/';
+							const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/';
 							if (isCI) {
 								const newLine = "%0A";
 								console.log(`::error file=origami.json,line=1,col=1::${message.replace(/\n/g, newLine)}`);
@@ -114,7 +114,7 @@ module.exports = cfg => {
 			return fileExists(origamiJsonPath)
 				.then(exists => {
 					if (!exists) {
-						return `No origami.json file found. To make this an origami component, create a file at ${path.join(config.cwd, '/origami.json')} following the format defined at: http://origami.ft.com/docs/syntax/origamijson/`;
+						return `No origami.json file found. To make this an Origami component, create a file at ${path.join(config.cwd, '/origami.json')} following the format defined at: https://origami.ft.com/docs/manifests/origami-json/`;
 					}
 				});
 		}

--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -49,7 +49,7 @@ function validEngines(engines) {
 		try {
 			const validSemver = semver.validRange(engines.npm);
 			if (validSemver) {
-				// origami 2.0 only supports npm 7 or newer
+				// npm 7 or newer is required for automated peer dependency install
 				const minSupportedNpm = semver.minVersion(engines.npm);
 				return semver.satisfies(minSupportedNpm, '^7');
 			}
@@ -134,11 +134,11 @@ async function packageJson(config) {
 			result.push(invalidExplanation);
 		}
 	} else {
-		result.push(`No package.json file found. To make this an origami component, create a package.json file following the format defined at: https://origami.ft.com/spec/v2/components/#package-management`);
+		result.push(`No package.json file found. To make this an origami component, create a package.json file following the format defined at: https://origami.ft.com/docs/components/code/#package-management`);
 	}
 
 	if (result.length > 0) {
-		const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management';
+		const message = 'Failed linting:\n\n' + result.join('\n') + '\n\nThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management';
 		if (isCI) {
 			const newLine = "%0A";
 			console.log(`::error file=package.json,line=1,col=1::${message.replace(/\n/g, newLine)}`);

--- a/test/unit/tasks/demo-build.test.js
+++ b/test/unit/tasks/demo-build.test.js
@@ -48,9 +48,10 @@ describe('Demo task', function () {
 				}, function (err) {
 					proclaim.equal(
 						err.message,
-						'No demos exist in origami.json file. Reference ' +
-						'https://origami.ft.com/spec to help configure demos ' +
-						'for the component.'
+						'No demos exist in the origami.json file. Reference ' +
+						'https://origami.ft.com/docs/manifests/origami-json/ ' +
+						'to configure demos in the component\'s origami.json ' +
+						'manifest file.'
 					);
 					fs.unlinkSync(path.resolve(oNoManifestPath, 'package.json'));
 					process.chdir(demoTestPath);

--- a/test/unit/tasks/verify-origami-json.test.js
+++ b/test/unit/tasks/verify-origami-json.test.js
@@ -67,7 +67,7 @@ describe('verify-origami-json', function () {
 			fs.removeSync(path.join(process.cwd(), '/origami.json'));
 			return verifyOrigamiJson().skip()
 				.then(skipped => {
-					proclaim.equal(skipped, `No origami.json file found. To make this an origami component, create a file at ${path.join(process.cwd(), '/origami.json')} following the format defined at: http://origami.ft.com/docs/syntax/origamijson/`);
+					proclaim.equal(skipped, `No origami.json file found. To make this an Origami component, create a file at ${path.join(process.cwd(), '/origami.json')} following the format defined at: https://origami.ft.com/docs/manifests/origami-json/`);
 				});
 		});
 
@@ -103,10 +103,10 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null\n' +
-						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.\n' +
+						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.\n' +
 						'The support property must be an email or url to an issue tracker for this project\n' +
 						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 				});
 		});
@@ -120,7 +120,7 @@ describe('verify-origami-json', function () {
 				proclaim.calledOnce(console.log);
 				proclaim.calledWithExactly(
 					console.log,
-					`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this project%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+					`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this project%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 				);
 			}
 		});
@@ -135,12 +135,12 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -155,12 +155,12 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -175,12 +175,12 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.'%0AThe support property must be an email or url to an issue tracker for this project%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.'%0AThe support property must be an email or url to an issue tracker for this project%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -196,12 +196,12 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -217,12 +217,12 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -264,13 +264,13 @@ describe('verify-origami-json', function () {
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
-						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.\n\n' +
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -286,13 +286,13 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The origamiVersion property must be a string.\n' +
-						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.\n\n' +
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiVersion property must be a string.%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiVersion property must be a string.%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -309,13 +309,13 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The origamiVersion property must be a string.\n' +
-						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.\n\n' +
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiVersion property must be a string.%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiVersion property must be a string.%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -350,12 +350,12 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The support property must be an email or url to an issue tracker for this project\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe support property must be an email or url to an issue tracker for this project%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe support property must be an email or url to an issue tracker for this project%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -371,18 +371,18 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The support property must be an email or url to an issue tracker for this project\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.equal(
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools only supports v2 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this project%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe origamiType property needs to be set to either "component", "imageset", "service", "cli", "library", "website", "config", "example", "meta", or null%0AThe origamiVersion property needs to be set to "2.0" or higher, this version of Origami Build tools does not support v1 of the Origami component specification.%0AThe support property must be an email or url to an issue tracker for this project%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -416,12 +416,12 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -437,12 +437,12 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe supportStatus property must be set to either "active", "maintained", "deprecated", "dead" or "experimental"%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -509,12 +509,12 @@ describe('verify-origami-json', function () {
 						verifiedOrigamiJson.message,
 						'Failed linting:\n\n' +
 						'The expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.\n\n' +
-						'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/'
+						'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.calledWithExactly(
 						console.log,
-						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+						`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AThe expanded property has been deprecated. Use the "hidden" property when a demo should not appear in the Registry.%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 					);
 				});
 		});
@@ -522,7 +522,7 @@ describe('verify-origami-json', function () {
 		describe('demo title', function() {
 			const expectedError = 'Failed linting:\n\n' +
 				'All demos require a title property which is non-empty and of type "string".\n\n' +
-				'The origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/';
+				'The origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/';
 			let origamiJSON = {};
 
 			beforeEach(() => {
@@ -559,7 +559,7 @@ describe('verify-origami-json', function () {
 						proclaim.calledOnce(console.log);
 						proclaim.calledWithExactly(
 							console.log,
-							`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AAll demos require a title property which is non-empty and of type "string".%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+							`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AAll demos require a title property which is non-empty and of type "string".%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 						);
 					});
 			});
@@ -579,7 +579,7 @@ describe('verify-origami-json', function () {
 						proclaim.calledOnce(console.log);
 						proclaim.calledWithExactly(
 							console.log,
-							`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AAll demos require a title property which is non-empty and of type "string".%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+							`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AAll demos require a title property which is non-empty and of type "string".%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 						);
 					});
 			});
@@ -597,7 +597,7 @@ describe('verify-origami-json', function () {
 						proclaim.calledOnce(console.log);
 						proclaim.calledWithExactly(
 							console.log,
-							`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AAll demos require a title property which is non-empty and of type "string".%0A%0AThe origami.json file does not conform to the specification at http://origami.ft.com/docs/syntax/origamijson/`
+							`::error file=origami.json,line=1,col=1::Failed linting:%0A%0AAll demos require a title property which is non-empty and of type "string".%0A%0AThe origami.json file does not conform to the expected format https://origami.ft.com/docs/manifests/origami-json/`
 						);
 					});
 			});

--- a/test/unit/tasks/verify-package-json.test.js
+++ b/test/unit/tasks/verify-package-json.test.js
@@ -84,14 +84,14 @@ describe('verify-package-json', function () {
 				proclaim.equal(
 					error.message,
 					'Failed linting:\n\n' +
-						'No package.json file found. To make this an origami component, create a package.json file following the format defined at: https://origami.ft.com/spec/v2/components/#package-management\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'No package.json file found. To make this an origami component, create a package.json file following the format defined at: https://origami.ft.com/docs/components/code/#package-management\n\n' +
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0ANo package.json file found. To make this an origami component, create a package.json file following the format defined at: https://origami.ft.com/spec/v2/components/#package-management%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0ANo package.json file found. To make this an origami component, create a package.json file following the format defined at: https://origami.ft.com/docs/components/code/#package-management%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 				);
 			}
 
@@ -118,13 +118,13 @@ describe('verify-package-json', function () {
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n' +
 						'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n' +
 						'Because the file `main.js` exists, the `browser` property is required. It must have the value `"main.js"`.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 				);
 			}
 
@@ -151,12 +151,12 @@ describe('verify-package-json', function () {
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n' +
 						'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n' +
 						'Because the file `main.js` exists, the `browser` property is required. It must have the value `"main.js"`.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0AA description property is required. It must be a string which describes the component.%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 				);
 			}
 
@@ -180,12 +180,12 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 						'A description property is required. It must be a string which describes the component.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management`]
 				);
 			}
 
@@ -209,12 +209,12 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 					'A description property is required. It must be a string which describes the component.\n\n' +
-					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management`]
+					[`::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management`]
 				);
 			}
 
@@ -238,12 +238,12 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 					'A description property is required. It must be a string which describes the component.\n\n' +
-					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AA description property is required. It must be a string which describes the component.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 				);
 			}
 
@@ -267,12 +267,12 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 					'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
-					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 				);
 			}
 
@@ -296,12 +296,12 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 					'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
-					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 				);
 			}
 
@@ -325,12 +325,12 @@ describe('verify-package-json', function () {
 					error.message,
 					'Failed linting:\n\n' +
 					'The keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.\n\n' +
-					'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+					'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 				);
 				proclaim.calledOnce(console.log);
 				proclaim.deepStrictEqual(
 					console.log.lastCall.args,
-					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+					["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe keywords property is required. It must be an array. It must contain only strings which relate to the component. It can also be an empty array.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 				);
 			}
 
@@ -356,12 +356,12 @@ describe('verify-package-json', function () {
 						error.message,
 						'Failed linting:\n\n' +
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.deepStrictEqual(
 						console.log.lastCall.args,
-						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 					);
 				}
 
@@ -385,12 +385,12 @@ describe('verify-package-json', function () {
 						error.message,
 						'Failed linting:\n\n' +
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.deepStrictEqual(
 						console.log.lastCall.args,
-						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 					);
 				}
 
@@ -414,12 +414,12 @@ describe('verify-package-json', function () {
 						error.message,
 						'Failed linting:\n\n' +
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.deepStrictEqual(
 						console.log.lastCall.args,
-						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 					);
 				}
 
@@ -443,12 +443,12 @@ describe('verify-package-json', function () {
 						error.message,
 						'Failed linting:\n\n' +
 						'The name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.\n\n' +
-						'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+						'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 					);
 					proclaim.calledOnce(console.log);
 					proclaim.deepStrictEqual(
 						console.log.lastCall.args,
-						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+						["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe name property is required. It must be within the `@financial-times` namespace and conform to the npmjs specification at https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 					);
 				}
 
@@ -485,12 +485,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'Because the file `main.js` exists, the `browser` property is required. It must have the value `"main.js"`.\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -514,12 +514,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'Because the file `main.js` exists, the `browser` property is required. It must have the value `"main.js"`.\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0ABecause the file `main.js` exists, the `browser` property is required. It must have the value `\"main.js\"`.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -582,12 +582,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'Because the file `main.js` does not exist, the `browser` property must not be set.\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0ABecause the file `main.js` does not exist, the `browser` property must not be set.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0ABecause the file `main.js` does not exist, the `browser` property must not be set.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -616,12 +616,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'The `type` property is required. It must be the string "module".\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -656,12 +656,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'The `type` property is required. It must be the string "module".\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe `type` property is required. It must be the string \"module\".%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -690,12 +690,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -718,12 +718,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -747,12 +747,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 
@@ -787,12 +787,12 @@ describe('verify-package-json', function () {
 							error.message,
 							'Failed linting:\n\n' +
 							'The engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.\n\n' +
-							'The package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management'
+							'The package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management'
 						);
 						proclaim.calledOnce(console.log);
 						proclaim.deepStrictEqual(
 							console.log.lastCall.args,
-							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/spec/v2/components/#package-management"]
+							["::error file=package.json,line=1,col=1::Failed linting:%0A%0AThe engines property is required. It must have the npm property set to a SemVer range which disallows versions lower than 7.0.0.%0A%0AThe package.json file does not conform to the specification at https://origami.ft.com/docs/components/code/#package-management"]
 						);
 					}
 


### PR DESCRIPTION
We decided to deprecate the Origami specification rather than
release v2.

Links to the Origami website 404 currently. Depends on:
Financial-Times/origami-website#361