### PR TITLE
Update test command to only expect primary Sass mixins for components.

### DIFF
--- a/lib/tasks/test-sass-compilation.js
+++ b/lib/tasks/test-sass-compilation.js
@@ -19,17 +19,21 @@ async function compilationTest(cwd, { silent, brand } = {
 	}
 
 	const name = await files.getComponentName();
+	const origamiManifest = await files.getOrigamiJson();
+
+	const requiresPrimaryMixin = origamiManifest.origamiType === 'component';
+
 	const primaryMixinName = camelCase(name);
 	const primaryMixinErrorCode = `OBT_NO_PRIMARY-MIXIN-${primaryMixinName}`;
-	const sassContent = await readFile(mainSassFilePath, 'utf8');
 
+	const sassContent = await readFile(mainSassFilePath, 'utf8');
 	const sassData = `
 		$system-code: "origami-build-tools";
 		${brand ? `$o-brand: ${brand};` : ''}
 
 		${sassContent}
 
-		${!silent ? `
+		${!silent && requiresPrimaryMixin ? `
 			@if not mixin-exists('${primaryMixinName}') {
 				@error '${primaryMixinErrorCode}';
 			};
@@ -55,7 +59,7 @@ async function compilationTest(cwd, { silent, brand } = {
 			throw new Error('CSS was output by default, without making a call to the component\'s Sass API.');
 		}
 
-		if (!silent && !css) {
+		if (!silent && requiresPrimaryMixin && !css) {
 			throw new Error(`No CSS was output when the primary mixin was included with "@include ${primaryMixinName}();". Does the component have no styles?`);
 		}
 

--- a/test/integration/test/test.test.js
+++ b/test/integration/test/test.test.js
@@ -67,11 +67,52 @@ describe('obt test', function () {
 		});
 	});
 
+	describe('given a library with no primary Sass mixin', function () {
+
+		beforeEach(async function () {
+			const name = 'o-test-component';
+			const tag = 'v2.2.20';
+			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+			await execa(obt, ['install']);
+		});
+
+		it('passes', async function () {
+			try {
+				await execa(obt, ['test']);
+			} catch (error) {
+				throw new Error(`Test command failed: ${error}`);
+			}
+		});
+	});
+
 	describe('given a component which outputs CSS by default on @import', function () {
 
 		beforeEach(async function () {
 			const name = 'o-test-component';
 			const tag = 'v2.2.18';
+			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+			await execa(obt, ['install']);
+		});
+
+		it('fails', async function () {
+			try {
+				await execa(obt, ['test']);
+				throw new Error('The test command did not throw an error as expected.');
+			} catch (error) {
+				proclaim.include(
+					error.stdout,
+					'CSS was output by default',
+					'Failed but with an unexpected error message: ' + error.stdout
+				);
+			}
+		});
+	});
+
+	describe('given a library which outputs CSS by default on @import', function () {
+
+		beforeEach(async function () {
+			const name = 'o-test-component';
+			const tag = 'v2.2.21';
 			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
 			await execa(obt, ['install']);
 		});

--- a/test/integration/test/test.test.js
+++ b/test/integration/test/test.test.js
@@ -26,108 +26,115 @@ describe('obt test', function () {
 		await rimraf(testDirectory);
 	});
 
-	describe('given a valid component', function () {
+	describe('given a component', function () {
 
-		beforeEach(async function () {
-			const name = 'o-test-component';
-			const tag = 'v2.2.9';
-			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
-			await execa(obt, ['install']);
+		describe('that is valid', function () {
+
+			beforeEach(async function () {
+				const name = 'o-test-component';
+				const tag = 'v2.2.9';
+				await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+				await execa(obt, ['install']);
+			});
+
+			it('passes', async function () {
+				try {
+					await execa(obt, ['test']);
+				} catch (error) {
+					throw new Error(`Test command failed: ${error}`);
+				}
+			});
 		});
 
-		it('passes', async function () {
-			try {
-				await execa(obt, ['test']);
-			} catch (error) {
-				throw new Error(`Test command failed: ${error}`);
-			}
+		describe('with no primary Sass mixin', function () {
+
+			beforeEach(async function () {
+				const name = 'o-test-component';
+				const tag = 'v2.2.17';
+				await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+				await execa(obt, ['install']);
+			});
+
+			it('fails', async function () {
+				try {
+					await execa(obt, ['test']);
+					throw new Error('The test command did not throw an error as expected.');
+				} catch (error) {
+					proclaim.include(
+						error.stdout,
+						'primary mixin',
+						'Failed but with an unexpected error message: ' + error.stdout
+					);
+				}
+			});
+		});
+
+		describe('which outputs CSS by default on @import', function () {
+
+			beforeEach(async function () {
+				const name = 'o-test-component';
+				const tag = 'v2.2.18';
+				await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+				await execa(obt, ['install']);
+			});
+
+			it('fails', async function () {
+				try {
+					await execa(obt, ['test']);
+					throw new Error('The test command did not throw an error as expected.');
+				} catch (error) {
+					proclaim.include(
+						error.stdout,
+						'CSS was output by default',
+						'Failed but with an unexpected error message: ' + error.stdout
+					);
+				}
+			});
+		});
+
+	});
+
+	describe('given a library', function () {
+		describe('with no primary Sass mixin', function () {
+
+			beforeEach(async function () {
+				const name = 'o-test-component';
+				const tag = 'v2.2.20';
+				await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+				await execa(obt, ['install']);
+			});
+
+			it('passes', async function () {
+				try {
+					await execa(obt, ['test']);
+				} catch (error) {
+					throw new Error(`Test command failed: ${error}`);
+				}
+			});
+		});
+
+		describe('which outputs CSS by default on @import', function () {
+
+			beforeEach(async function () {
+				const name = 'o-test-component';
+				const tag = 'v2.2.21';
+				await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+				await execa(obt, ['install']);
+			});
+
+			it('fails', async function () {
+				try {
+					await execa(obt, ['test']);
+					throw new Error('The test command did not throw an error as expected.');
+				} catch (error) {
+					proclaim.include(
+						error.stdout,
+						'CSS was output by default',
+						'Failed but with an unexpected error message: ' + error.stdout
+					);
+				}
+			});
 		});
 	});
 
-	describe('given a component with no primary Sass mixin', function () {
-
-		beforeEach(async function () {
-			const name = 'o-test-component';
-			const tag = 'v2.2.17';
-			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
-			await execa(obt, ['install']);
-		});
-
-		it('fails', async function () {
-			try {
-				await execa(obt, ['test']);
-				throw new Error('The test command did not throw an error as expected.');
-			} catch (error) {
-				proclaim.include(
-					error.stdout,
-					'primary mixin',
-					'Failed but with an unexpected error message: ' + error.stdout
-				);
-			}
-		});
-	});
-
-	describe('given a library with no primary Sass mixin', function () {
-
-		beforeEach(async function () {
-			const name = 'o-test-component';
-			const tag = 'v2.2.20';
-			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
-			await execa(obt, ['install']);
-		});
-
-		it('passes', async function () {
-			try {
-				await execa(obt, ['test']);
-			} catch (error) {
-				throw new Error(`Test command failed: ${error}`);
-			}
-		});
-	});
-
-	describe('given a component which outputs CSS by default on @import', function () {
-
-		beforeEach(async function () {
-			const name = 'o-test-component';
-			const tag = 'v2.2.18';
-			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
-			await execa(obt, ['install']);
-		});
-
-		it('fails', async function () {
-			try {
-				await execa(obt, ['test']);
-				throw new Error('The test command did not throw an error as expected.');
-			} catch (error) {
-				proclaim.include(
-					error.stdout,
-					'CSS was output by default',
-					'Failed but with an unexpected error message: ' + error.stdout
-				);
-			}
-		});
-	});
-
-	describe('given a library which outputs CSS by default on @import', function () {
-
-		beforeEach(async function () {
-			const name = 'o-test-component';
-			const tag = 'v2.2.21';
-			await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
-			await execa(obt, ['install']);
-		});
-
-		it('fails', async function () {
-			try {
-				await execa(obt, ['test']);
-				throw new Error('The test command did not throw an error as expected.');
-			} catch (error) {
-				proclaim.include(
-					error.stdout,
-					'CSS was output by default',
-					'Failed but with an unexpected error message: ' + error.stdout
-				);
-			}
-		});
-	});
 });


### PR DESCRIPTION
Libraries may not have primary mixins. We would still expect them
to only output CSS when their Sass API is called though, not by
default on import.