### PR TITLE
Remove requirement that the primary mixin produces css by default

### DIFF
--- a/lib/tasks/test-sass-compilation.js
+++ b/lib/tasks/test-sass-compilation.js
@@ -59,10 +59,6 @@ async function compilationTest(cwd, { silent, brand } = {
 			throw new Error('CSS was output by default, without making a call to the component\'s Sass API.');
 		}
 
-		if (!silent && requiresPrimaryMixin && !css) {
-			throw new Error(`No CSS was output when the primary mixin was included with "@include ${primaryMixinName}();". Does the component have no styles?`);
-		}
-
 	} catch (error) {
 		const missingPrimaryMixin = error.message.includes(primaryMixinErrorCode);
 		const missingPrimaryMixinMessage = 'Origami components require a ' +


### PR DESCRIPTION
Not all components provide css by default for a particular brand, for example o-fonts' whitelabel mode has no css.
Percy's visual testing catches any regression a component would have if it used to produce css and no longer does