### PR TITLE
do not run sass compilation test if there is no main sass file

### DIFF
--- a/lib/tasks/test-sass-compilation.js
+++ b/lib/tasks/test-sass-compilation.js
@@ -6,9 +6,12 @@ const ListrRenderer = require('../helpers/listr-renderer');
 const isCI = require('is-ci');
 const { camelCase } = require('lodash');
 const ftSass = require('@financial-times/sass');
+const denodeify = require('util').promisify;
+const fsOpen = denodeify(require('fs').open);
 const { readFile } = require('fs/promises');
 const execa = require('execa');
 
+const fileExists = file => fsOpen(file, 'r').then(() => true).catch(() => false);
 async function compilationTest(cwd, { silent, brand } = {
 	silent: false,
 	brand: false
@@ -119,6 +122,9 @@ module.exports = function (cfg) {
 				concurrent: true
 			});
 		},
-		skip: () => !files.getMainSassPath(config.cwd)
+		skip: async () => {
+			const exists = await fileExists(await files.getMainSassPath(config.cwd));
+			return !exists;
+		}
 	};
 };

--- a/test/integration/test/test.test.js
+++ b/test/integration/test/test.test.js
@@ -135,6 +135,24 @@ describe('obt test', function () {
 				}
 			});
 		});
+
+		describe('with no Sass', function () {
+
+			beforeEach(async function () {
+				const name = 'o-test-component';
+				const tag = 'v2.2.22';
+				await execa('git', ['clone', '--depth', 1, '--branch', tag, `https://github.com/Financial-Times/${name}.git`, './']);
+				await execa(obt, ['install']);
+			});
+
+			it('passes', async function () {
+				try {
+					await execa(obt, ['test']);
+				} catch (error) {
+					throw new Error(`Test command failed: ${error}`);
+				}
+			});
+		});
 	});
 
 });


### PR DESCRIPTION
currently there is a bug in the test-sass-compilation module where it would try and run sass tests on libraries which have no sass such as o-autoinit and o-errors. This fixes the bug 👍 

