### PR TITLE
Skip pa11y tests when the `--ignore-bower` flag is set.

### DIFF
--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -81,19 +81,20 @@ module.exports = function (cfg) {
 					await buildDemo({
 						brand,
 						demoFilter: 'pa11y',
-						ignoreBower: config.ignoreBower,
 					});
 					return pa11yTest(config, brand);
 				}
 			}
 		},
-		skip: function () {
-			return fileExists(path.join(config.cwd, '/demos/src/pa11y.mustache'))
-				.then(exists => {
-					if (!exists) {
-						return `No Pa11y demo found. To run Pa11y against this project, create a file at ${path.join(config.cwd, '/demos/local/pa11y.html')}`;
-					}
-				});
+		skip: async function () {
+			if (config.ignoreBower) {
+				return `Skipping pa11y tests. They are not supported in this version of origami-build-tools when the \`--ignore-bower\` flag is set.`;
+			}
+			const exists = await fileExists(path.join(config.cwd, '/demos/src/pa11y.mustache'))
+			if (!exists) {
+				return `No Pa11y demo found. To run Pa11y against this project, create a file at ${path.join(config.cwd, '/demos/local/pa11y.html')}`;
+			}
+			return false;
 		}
 	};
 };

--- a/lib/tasks/pa11y.js
+++ b/lib/tasks/pa11y.js
@@ -90,7 +90,7 @@ module.exports = function (cfg) {
 			if (config.ignoreBower) {
 				return `Skipping pa11y tests. They are not supported in this version of origami-build-tools when the \`--ignore-bower\` flag is set.`;
 			}
-			const exists = await fileExists(path.join(config.cwd, '/demos/src/pa11y.mustache'))
+			const exists = await fileExists(path.join(config.cwd, '/demos/src/pa11y.mustache'));
 			if (!exists) {
 				return `No Pa11y demo found. To run Pa11y against this project, create a file at ${path.join(config.cwd, '/demos/local/pa11y.html')}`;
 			}


### PR DESCRIPTION
`origami-ci-tools` runs `obt test --ignore-bower`, to test the
npm package of a component which supports Bower and npm is correct:
https://github.com/Financial-Times/origami-ci-tools/blob/master/commands/branch.js#L52

This used to not run pa11y tests as the pa11y demo is not built by
`origami-ci-tools`, and Origami Build Tools used to skip pa11y tests
if a built pa11y demo was not found. However origami-build-tools
was updated to check for pa11y source code and build the pa11y
demo if it exists:
https://github.com/Financial-Times/origami-build-tools/pull/933/files#diff-6c44fc3cf122c89eee3ab192bd97d1a853d25adb56fa750332e79aac7ad230d4R90

`origami-component-converter`, used to generate the npm bundle, does
not support demo source code so the pa11y build fails, and thus
`origami-ci-tools` fails, and thus we can't make minor/patch release
to old versions of components which still support Bower.

By skipping pa11y tests if `--ignore-bower` is set we avoid this
error.