### PR TITLE
close the filehandler that fileExists creates

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -1,11 +1,26 @@
 'use strict';
 
-const { readFile, open } = require('fs/promises');
+const { readFile, access } = require('fs/promises');
+const { constants } = require('fs');
 const path = require('path');
 const denodeify = require('util').promisify;
 const deglob = denodeify(require('deglob'));
 
-const fileExists = (file) => open(file, 'r').then(() => true).catch(() => false);
+/**
+ * Node.JS no longer has an fs.exists method.
+ * Instead we use the fs.access method and check we can read the file.
+ * fs.access will throw an error if the file does not exist.
+ * @param {string} file file-system path to the file you are wanting to check exists or not
+ * @returns {Promise.<boolean>} Whether the file exists
+*/
+async function fileExists(file) {
+	try {
+		await access(file, constants.R_OK);
+		return true;
+	} catch (error) {
+		return false;
+	}
+}
 
 function getBuildFolderPath(cwd) {
 	cwd = cwd || process.cwd();
@@ -165,6 +180,7 @@ function getSassIncludePaths (cwd, config = {sassIncludePaths: []}) {
 	].map(pathname => path.join(cwd, pathname)));
 }
 
+module.exports.fileExists = fileExists;
 module.exports.readIfExists = readIfExists;
 module.exports.getBuildFolderPath = getBuildFolderPath;
 module.exports.getMainSassPath = getMainSassPath;

--- a/lib/tasks/demo-build.js
+++ b/lib/tasks/demo-build.js
@@ -10,7 +10,6 @@ const constructPolyfillUrl = require('../helpers/construct-polyfill-url');
 const mustache = require('mustache');
 const denodeify = require('util').promisify;
 
-const fileExists = file => denodeify(fs.open)(file, 'r').then(() => true).catch(() => false);
 const readFile = denodeify(fs.readFile);
 const outputFile = denodeify(fs.outputFile);
 
@@ -18,7 +17,7 @@ function buildDemoSass(buildConfig) {
 	const src = path.join(buildConfig.cwd, '/' + buildConfig.demo.sass);
 	const dest = path.join(buildConfig.cwd, '/demos/local/');
 
-	return fileExists(src)
+	return files.fileExists(src)
 		.then(exists => {
 			if (!exists) {
 				const e = new Error('Sass file not found: ' + src);
@@ -46,7 +45,7 @@ function buildDemoJs(buildConfig) {
 	const src = path.join(buildConfig.cwd, '/' + buildConfig.demo.js);
 	const destFolder = path.join(buildConfig.cwd, '/demos/local/');
 	const dest = path.basename(buildConfig.demo.js);
-	return fileExists(src)
+	return files.fileExists(src)
 		.then(exists => {
 			if (!exists) {
 				const e = new Error('JavaScript file not found: ' + src);
@@ -110,7 +109,7 @@ function buildDemoHtml(buildConfig) {
 	return loadDemoData(buildConfig)
 		.then(demoData => {
 			data = demoData;
-			return fileExists(src);
+			return files.fileExists(src);
 		})
 		.then(exists => {
 			if (!exists) {

--- a/lib/tasks/test-sass-compilation.js
+++ b/lib/tasks/test-sass-compilation.js
@@ -6,10 +6,9 @@ const ListrRenderer = require('../helpers/listr-renderer');
 const isCI = require('is-ci');
 const { camelCase } = require('lodash');
 const ftSass = require('@financial-times/sass');
-const { readFile, open } = require('fs/promises');
+const { readFile } = require('fs/promises');
 const execa = require('execa');
 
-const fileExists = file => open(file, 'r').then(() => true).catch(() => false);
 async function compilationTest(cwd, { silent, brand } = {
 	silent: false,
 	brand: false
@@ -121,7 +120,7 @@ module.exports = function (cfg) {
 			});
 		},
 		skip: async () => {
-			const exists = await fileExists(await files.getMainSassPath(config.cwd));
+			const exists = await files.fileExists(await files.getMainSassPath(config.cwd));
 			return !exists;
 		}
 	};

--- a/lib/tasks/verify-javascript.js
+++ b/lib/tasks/verify-javascript.js
@@ -5,11 +5,9 @@ const path = require('path');
 const ESLint = require('eslint').ESLint;
 const denodeify = require('util').promisify;
 const deglob = denodeify(require('deglob'));
-const { open } = require('fs/promises');
 const log = require('../helpers/log');
+const {fileExists} = require('../helpers/files');
 const isCI = require('is-ci');
-
-const fileExists = file => open(file, 'r').then(() => true).catch(() => false);
 
 async function lint (config) {
 	const hasJS = await projectHasJavaScriptFiles(config);

--- a/lib/tasks/verify-origami-json.js
+++ b/lib/tasks/verify-origami-json.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const process = require('process');
-const { readFile, open} = require('fs/promises');
+const { readFile } = require('fs/promises');
+const { fileExists} = require('../helpers/files');
 const path = require('path');
 const isCI = require('is-ci');
-
-const fileExists = file => open(file, 'r').then(() => true).catch(() => false);
 
 // https://origami.ft.com/docs/manifests/origami-json/#origamitype
 // "component": A front-end component that follows the component specification

--- a/lib/tasks/verify-package-json.js
+++ b/lib/tasks/verify-package-json.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const process = require('process');
-const { readFile, open } = require('fs/promises');
+const { readFile } = require('fs/promises');
+const { fileExists} = require('../helpers/files');
 const path = require('path');
 const isCI = require('is-ci');
 const semver = require('semver');
-
-const fileExists = file => open(file, 'r').then(() => true).catch(() => false);
 
 /**
  * Checks whether description conforms to the origami package.json description specification.

--- a/lib/tasks/verify-readme.js
+++ b/lib/tasks/verify-readme.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const process = require('process');
-const { readFile, open } = require('fs/promises');
+const { readFile } = require('fs/promises');
 const path = require('path');
 const isCI = require('is-ci');
 const vfile = require('vfile');
@@ -9,8 +9,7 @@ const remark = require('remark');
 const remarkLint = require('remark-lint');
 const report = require('vfile-reporter');
 const log = require('../helpers/log');
-
-const fileExists = file => open(file, 'r').then(() => true).catch(() => false);
+const { fileExists} = require('../helpers/files');
 
 async function origamiJson(config) {
 	// Error if there is no readme to verify.

--- a/lib/tasks/verify-sass.js
+++ b/lib/tasks/verify-sass.js
@@ -4,11 +4,9 @@ const process = require('process');
 const path = require('path');
 const denodeify = require('util').promisify;
 const deglob = denodeify(require('deglob'));
-const { open } = require('fs/promises');
 const isCI = require('is-ci');
 const execa = require('execa');
-
-const fileExists = file => open(file, 'r').then(() => true).catch(() => false);
+const { fileExists} = require('../helpers/files');
 async function sassLint(config) {
 	const hasScss = await projectHasScssFiles(config);
 

--- a/test/integration/helpers/fileExists.js
+++ b/test/integration/helpers/fileExists.js
@@ -1,16 +1,20 @@
 'use strict';
 
-const open = require('fs/promises').open;
+const { access } = require('fs/promises');
+const { constants } = require('fs');
 
 /**
  * Node.JS no longer has an fs.exists method.
- * Instead we use the fs.open method in read (`r`) mode.
- * fs.open will throw an error if the file does not exist.
+ * Instead we use the fs.access method and check we can read the file.
+ * fs.access will throw an error if the file does not exist.
  * @param {string} file file-system path to the file you are wanting to check exists or not
  * @returns {Promise.<boolean>} Whether the file exists
 */
-module.exports = function fileExists(file) {
-	return open(file, 'r')
-		.then(() => true)
-		.catch(() => false);
+module.exports = async function fileExists(file) {
+	try {
+		await access(file, constants.R_OK);
+		return true;
+	} catch (error) {
+		return false;
+	}
 };

--- a/test/integration/verify/verify.test.js
+++ b/test/integration/verify/verify.test.js
@@ -7,10 +7,9 @@ const process = require('process');
 const proclaim = require('proclaim');
 const obtBinPath = require('../helpers/obtpath');
 const rimraf = require('../helpers/delete');
-const { writeFile, open } = require('fs/promises');
+const fileExists = require('../helpers/fileExists');
+const { writeFile } = require('fs/promises');
 const tmpdir = require('../helpers/tmpdir');
-
-const fileExists = file => open(file, 'r').then(() => true).catch(() => false);
 
 describe('obt verify', function () {
 	let obt;


### PR DESCRIPTION
NodeJS is deprecating the automatic closing of fileHandlers during garbage collection.

This commit updates the codebase to explicitly close the fileHandlers instead of relying on the deprecated behaviour.

Below is the message that is displayed when running obt prior to this commit:

>DeprecationWarning: Closing a FileHandle object on garbage collection is deprecated. 
>Please close FileHandle objects explicitly using FileHandle.prototype.close().
>In the future, an error will be thrown if a file descriptor is closed during garbage collection.