### PR TITLE
Do not verify that .npmignore does not include `demos/local`

### DIFF
--- a/lib/tasks/verify-dot-npmignore.js
+++ b/lib/tasks/verify-dot-npmignore.js
@@ -20,7 +20,7 @@ async function dotNpmignore(config) {
 
 		let lineNumber = 0;
 		for await (const line of reader) {
-			const match = line.trim().match(/(main\.scss|main\.js|src\/?|demos\/?)/);
+			const match = line.trim().match(/(main\.scss|main\.js|src\/?|demos\/?$|demos\/(?!local))/);
 			if (match) {
 				const filename = match[1];
 				result.push({

--- a/test/integration/verify/fixtures/npmignore/.npmignore
+++ b/test/integration/verify/fixtures/npmignore/.npmignore
@@ -1,2 +1,3 @@
 honk
 test/
+demos/local


### PR DESCRIPTION
We want to publish demo source but not demo builds.

For more see: https://github.com/Financial-Times/origami-build-tools/pull/1039