### PR TITLE
Mark obt as deprecated

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -4,7 +4,7 @@
 	"origamiVersion": "2.0",
 	"keywords": [],
 	"support": "https://github.com/Financial-Times/origami-build-tools/issues",
-	"supportStatus": "active",
+	"supportStatus": "deprecated",
 	"supportContact": {
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/origami-support"


### PR DESCRIPTION
Since moving origami components and related projects into a single repository, we no longer need or use origami-build-tools